### PR TITLE
docs: align alpha access URL and contact wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,6 @@ Each example directory contains a `README.md` with specific setup instructions.
 ## Contributing & Contact
 
 - Suggest an example: open an issue with label `example-request`
-- Alpha program access and integration questions: [hello@axme.ai](mailto:hello@axme.ai)
+- Alpha access: https://cloud.axme.ai/alpha · Contact and suggestions: [hello@axme.ai](mailto:hello@axme.ai)
 - Security disclosures: see [SECURITY.md](SECURITY.md)
 - Contribution guidelines: [CONTRIBUTING.md](CONTRIBUTING.md)


### PR DESCRIPTION
## Summary
- Update README alpha-access wording to use https://cloud.axme.ai/alpha.
- Keep hello@axme.ai as the contact channel for suggestions and communication.

## Test plan
- [x] Verify README alpha-access lines point to https://cloud.axme.ai/alpha.
- [x] Verify hello@axme.ai remains for contact/suggestions.
