### PR TITLE
docs: sync examples README and roadmap updates

### DIFF
--- a/CONTENT_ROADMAP_ALPHA.md
+++ b/CONTENT_ROADMAP_ALPHA.md
@@ -1,0 +1,52 @@
+# axme-examples Content Roadmap (Alpha)
+
+This roadmap defines what must be implemented before `axme-examples` can claim full README maturity.
+
+## Adoption-Driven Targets
+
+Derived from `axme-local-internal/plans/ADOPTION_PRIMARY_ACTIONS_EXECUTION_PLAN.md`:
+
+- At least 3 runnable Tier-1 framework examples in this repository.
+- One-command run path per example.
+- Problem-first README opening (first 5 lines).
+- Explicit Alpha disclaimer in all example READMEs.
+- CI that executes examples (not smoke-only file checks).
+
+## Mandatory Example Baseline (Each Example)
+
+- Source code and dependency manifest committed.
+- `.env.example` present.
+- `run` command and expected output documented.
+- Failure/retry behavior documented.
+- Attribution footer: `Built using AXME (AXP)`.
+
+## Phase Plan
+
+### Phase A - Repository skeleton
+
+- Create `examples/` subfolders for selected Tier-1 targets.
+- Add shared helper scripts (`scripts/validate_examples.sh`).
+- Replace README-only smoke CI with runnable validation jobs.
+
+### Phase B - Tier-1 initial delivery
+
+Implement at least three:
+
+- `examples/langgraph-distributed-agents`
+- `examples/autogen-cross-machine-handoff`
+- `examples/openai-agents-handoff-bridge`
+
+### Phase C - Docs and discoverability
+
+- Add `docs/example-matrix.md` with use-case and support status.
+- Tag repository with backend + agent-discovery topics.
+- Link examples from `axme-docs` integration quickstart pages.
+
+## Definition of Ready for Full README
+
+Full README overhaul is unlocked only when:
+
+1. Three runnable examples are merged.
+2. CI executes example flows on PR.
+3. Example matrix is published.
+4. Alpha disclaimer and usage limits are consistently documented.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,43 @@
 
 ---
 
+## What Is AXME?
+
+AXME is a coordination infrastructure for durable execution of long-running intents across distributed systems.
+
+It provides a model for executing **intents** — requests that may take minutes, hours, or longer to complete — across services, agents, and human participants.
+
+## AXP — the Intent Protocol
+
+At the core of AXME is **AXP (Intent Protocol)** — an open protocol that defines contracts and lifecycle rules for intent processing.
+
+AXP can be implemented independently.  
+The open part of the platform includes:
+
+- the protocol specification and schemas
+- SDKs and CLI for integration
+- conformance tests
+- implementation and integration documentation
+
+## AXME Cloud
+
+**AXME Cloud** is the managed service that runs AXP in production together with **The Registry** (identity and routing).
+
+It removes operational complexity by providing:
+
+- reliable intent delivery and retries  
+- lifecycle management for long-running operations  
+- handling of timeouts, waits, reminders, and escalation  
+- observability of intent status and execution history  
+
+State and events can be accessed through:
+
+- API and SDKs  
+- event streams and webhooks  
+- the cloud console
+
+---
+
 ## What This Repository Is For
 
 `axme-examples` is the fastest way to go from "I have an API key" to "I have working code." Each example is:
@@ -73,7 +110,11 @@ Once examples are available:
 
 ```bash
 git clone https://github.com/AxmeAI/axme-examples.git
-cd axme-examples/python/send-intent-basic
+cd axme-examples
+ls
+
+# Enter one of the published example directories
+cd <language>/<example-name>
 
 # Set your API key
 export AXME_API_KEY="your-key-here"


### PR DESCRIPTION
## Summary
- rebase the examples tmp branch on latest main without rolling back existing README updates
- add the alpha content roadmap document and keep README refinements from the branch
- align alpha access/contact wording with current policy

## Test plan
- [ ] Review README and roadmap rendering
- [ ] Required GitHub checks on this PR

Made with [Cursor](https://cursor.com)