### PR TITLE
feat: split examples into cloud and protocol hubs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.env
+**/.env
+**/.venv/
+**/.venv-e2e/
+**/node_modules/
+**/__pycache__/

--- a/CONTENT_ROADMAP_ALPHA.md
+++ b/CONTENT_ROADMAP_ALPHA.md
@@ -6,7 +6,15 @@ This roadmap defines what must be implemented before `axme-examples` can claim f
 
 Derived from `axme-local-internal/plans/ADOPTION_PRIMARY_ACTIONS_EXECUTION_PLAN.md`:
 
-- At least 3 runnable Tier-1 framework examples in this repository.
+- 4 runnable canonical developer-infra examples in this repository:
+  - `examples/approval-workflow`
+  - `examples/external-callback`
+  - `examples/retry-workflow`
+  - `examples/multi-service-coordination`
+- Protocol-only examples for open ecosystem path:
+  - `protocol/create-intent`
+  - `protocol/minimal-axp-service`
+  - `protocol/conformance-runner`
 - One-command run path per example.
 - Problem-first README opening (first 5 lines).
 - Explicit Alpha disclaimer in all example READMEs.
@@ -24,23 +32,30 @@ Derived from `axme-local-internal/plans/ADOPTION_PRIMARY_ACTIONS_EXECUTION_PLAN.
 
 ### Phase A - Repository skeleton
 
-- Create `examples/` subfolders for selected Tier-1 targets.
+- Create `examples/` subfolders by canonical use-case.
 - Add shared helper scripts (`scripts/validate_examples.sh`).
 - Replace README-only smoke CI with runnable validation jobs.
 
-### Phase B - Tier-1 initial delivery
+### Phase B - Canonical core delivery
 
-Implement at least three:
+Implement all four:
 
-- `examples/langgraph-distributed-agents`
-- `examples/autogen-cross-machine-handoff`
-- `examples/openai-agents-handoff-bridge`
+- `examples/approval-workflow`
+- `examples/external-callback`
+- `examples/retry-workflow`
+- `examples/multi-service-coordination`
+
+Language support policy:
+
+- Full runnable flows: Python + TypeScript.
+- Go/Java/.NET: snippets-only lane under `snippets/`.
 
 ### Phase C - Docs and discoverability
 
 - Add `docs/example-matrix.md` with use-case and support status.
 - Tag repository with backend + agent-discovery topics.
 - Link examples from `axme-docs` integration quickstart pages.
+- Keep cloud/protocol split explicit in README and docs.
 
 ## Definition of Ready for Full README
 

--- a/README.md
+++ b/README.md
@@ -1,150 +1,169 @@
 # axme-examples
 
-**Reference examples and starter templates for the AXME platform.** Runnable, well-commented code showing how to integrate AXME across Python, TypeScript, Go, Java, and .NET — organized by use case, not by language.
+Reference, runnable AXME examples organized by **use case**, not by language.
 
-> **Alpha** · Examples are being added in waves alongside the platform. Check back often.  
-> Requests for specific examples → [hello@axme.ai](mailto:hello@axme.ai)
+> **Alpha**: APIs and behavior are still evolving.  
+> Get API key: <https://cloud.axme.ai/alpha> · Contact: [hello@axme.ai](mailto:hello@axme.ai)
 
----
+## Runtime Model
 
-## What Is AXME?
+AXME Cloud currently provides the runtime environment for executing intents.
 
-AXME is a coordination infrastructure for durable execution of long-running intents across distributed systems.
+Publicly available:
 
-It provides a model for executing **intents** — requests that may take minutes, hours, or longer to complete — across services, agents, and human participants.
-
-## AXP — the Intent Protocol
-
-At the core of AXME is **AXP (Intent Protocol)** — an open protocol that defines contracts and lifecycle rules for intent processing.
-
-AXP can be implemented independently.  
-The open part of the platform includes:
-
-- the protocol specification and schemas
-- SDKs and CLI for integration
+- AXP spec and schemas
+- SDKs
+- CLI
 - conformance tests
-- implementation and integration documentation
+- docs
+- integration examples
 
-## AXME Cloud
+Managed/closed:
 
-**AXME Cloud** is the managed service that runs AXP in production together with **The Registry** (identity and routing).
+- AXME Cloud runtime
+- Registry
+- control plane
+- production execution infrastructure
 
-It removes operational complexity by providing:
+## Example Families
 
-- reliable intent delivery and retries  
-- lifecycle management for long-running operations  
-- handling of timeouts, waits, reminders, and escalation  
-- observability of intent status and execution history  
+This repository is split into two families:
 
-State and events can be accessed through:
+- **Cloud examples** (`cloud/` + `examples/`)  
+  Runnable end-to-end scenarios that use AXME Cloud runtime.
+- **Protocol examples** (`protocol/`)  
+  AXP-only examples that do not require AXME Cloud runtime.
 
-- API and SDKs  
-- event streams and webhooks  
-- the cloud console
+Cloud examples are the product path; protocol examples are for teams implementing or validating AXP-compatible components.
 
----
+## Requirements
 
-## What This Repository Is For
+These examples run against **AXME Cloud**.
 
-`axme-examples` is the fastest way to go from "I have an API key" to "I have working code." Each example is:
+You need:
 
-- **Runnable** — copy, fill in your API key, and run
-- **Self-contained** — minimal dependencies, no boilerplate to untangle
-- **Annotated** — comments explain *why*, not just *what*
-- **Tested** — CI validates all examples against the staging gateway
+- AXME Cloud API key in `AXME_API_KEY` (issued on the landing page)
 
----
+Get API key at:
 
-## Example Themes
+- <https://cloud.axme.ai/alpha>
 
-### Intent Lifecycle Without Polling
+Environment model:
 
-The AXME platform delivers state transitions via SSE — you don't need to poll. Examples in this category show how to write intent-driven code that reacts to events rather than checking status in a loop.
+- `AXME_API_KEY` - required; value is a workspace/service-account key (`axme_sa_...`) sent as `x-api-key`
+- `AXME_BASE_URL` - optional override; defaults to `https://api.cloud.axme.ai`
 
-![Intent Lifecycle State Machine](docs/diagrams/01-intent-lifecycle-state-machine.svg)
+## Auth Model For Examples
 
-*Each state transition triggers a real-time event. Your code subscribes once and receives `PENDING → PROCESSING → WAITING → DELIVERED → RESOLVED` transitions as they happen.*
+- Machine-to-machine examples in this repository use `AXME_API_KEY` only.
+- No actor/session token is required for the canonical examples.
+- Actor token (`Authorization: Bearer <access_token>`) is a separate user/session layer and is only needed for actor-scoped enterprise operations.
 
-### Transport Fallback and Retry-Safe Flows
+## Additional Keys For Bots/Processes
 
-Transport failures are handled by the platform, but your integration code should be written to handle them gracefully too. Examples here show idempotency key usage, retry-safe patterns, and how to handle `429` and `503` responses.
-
-![Transport Selection and Fallbacks](docs/diagrams/05-transport-selection-and-fallbacks.svg)
-
-*The platform automatically falls back to the next available transport (HTTP → queue → manual) when delivery fails. Your webhook handler should be idempotent: the same event may arrive more than once.*
-
-### Observability-First Async Operations
-
-Examples showing how to instrument your AXME integration: correlation IDs, structured logging, intent lifecycle traces, and SLO-aware timeout handling.
-
-![Observability and SLO Alerts](docs/diagrams/03-observability-slos-alerts.svg)
-
-*Best practice: propagate the `X-Correlation-Id` header from the intent through your internal service calls. This makes it possible to trace a full intent lifecycle across your stack.*
-
----
-
-## Planned Example Matrix
-
-| Use Case | Python | TypeScript | Go | Java | .NET |
-|---|---|---|---|---|---|
-| Send an intent (basic) | 🔜 | 🔜 | 🔜 | 🔜 | 🔜 |
-| Observe events (SSE) | 🔜 | 🔜 | 🔜 | 🔜 | 🔜 |
-| Human-in-the-loop approval | 🔜 | 🔜 | 🔜 | — | — |
-| Retry-safe with idempotency key | 🔜 | 🔜 | 🔜 | 🔜 | 🔜 |
-| Webhook receiver + signature verify | 🔜 | 🔜 | — | — | — |
-| Transport fallback handling | 🔜 | 🔜 | — | — | — |
-
----
-
-## Repository Status
-
-Bootstrap phase. Examples are being built in priority order (Tier 1 first).
-
-See [`CONTENT_ROADMAP_ALPHA.md`](CONTENT_ROADMAP_ALPHA.md) for the full plan and timeline.
-
----
-
-## How to Run an Example
-
-Once examples are available:
+If you need one key per bot/process, create extra service accounts and keys (do not run onboarding again):
 
 ```bash
-git clone https://github.com/AxmeAI/axme-examples.git
-cd axme-examples
-ls
+axme service-accounts create \
+  --org-id "<org_id>" \
+  --workspace-id "<workspace_id>" \
+  --name "bot-processor-a" \
+  --created-by-actor-id "<actor_id>"
 
-# Enter one of the published example directories
-cd <language>/<example-name>
+axme service-accounts list --org-id "<org_id>" --workspace-id "<workspace_id>"
 
-# Set your API key
-export AXME_API_KEY="your-key-here"
-export AXME_BASE_URL="https://gateway.axme.ai"
-
-# Run
-python example.py
+axme service-accounts keys create \
+  --service-account-id "<sa_id>" \
+  --created-by-actor-id "<actor_id>"
 ```
 
-Each example directory contains a `README.md` with specific setup instructions.
+## Cloud Canonical Example Set
 
----
+| Example | What it demonstrates | Python | TypeScript |
+|---|---|---|---|
+| `examples/approval-workflow` | Automatic approval fast path (immediate `resume`/completion) | ✅ | ✅ |
+| `examples/external-callback` | External system callback resumes intent flow | ✅ | ✅ |
+| `examples/retry-workflow` | Retry with backoff + idempotent intent create semantics | ✅ | ✅ |
+| `examples/multi-service-coordination` | Coordinating multiple services under one lifecycle | ✅ | ✅ |
+
+See cloud index: [`cloud/README.md`](cloud/README.md)
+
+## Protocol Example Set (No Cloud Runtime Required)
+
+- `protocol/create-intent` - intent envelope shape and protocol-level submission flow
+- `protocol/minimal-axp-service` - minimal AXP-compatible service lifecycle (`accept -> progress -> complete`)
+- `protocol/conformance-runner` - run conformance suite against custom implementation
+
+See protocol index: [`protocol/README.md`](protocol/README.md)
+
+## Repository Layout
+
+```text
+cloud/
+  README.md
+  approval-workflow/
+  external-callback/
+  retry-workflow/
+  multi-service-coordination/
+examples/
+  approval-workflow/
+    .env.example
+    README.md
+    python/
+    typescript/
+  external-callback/
+  retry-workflow/
+  multi-service-coordination/
+protocol/
+  create-intent/
+  minimal-axp-service/
+  conformance-runner/
+snippets/
+  README.md
+```
+
+## Quick Start
+
+### Python
+
+```bash
+cd examples/approval-workflow/python
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+cp ../.env.example ../.env
+# edit ../.env and set AXME_API_KEY
+# optional override for staging/dev:
+# export AXME_BASE_URL="https://api.cloud.axme.ai"
+python main.py
+```
+
+### TypeScript
+
+```bash
+cd examples/approval-workflow/typescript
+npm install
+cp ../.env.example ../.env
+# edit ../.env and set AXME_API_KEY
+# optional override for staging/dev:
+# export AXME_BASE_URL="https://api.cloud.axme.ai"
+npm run start
+```
 
 ## Related Repositories
 
 | Repository | Role |
 |---|---|
-| [axme-docs](https://github.com/AxmeAI/axme-docs) | Full API reference — examples link here for deeper context |
-| [axme-sdk-python](https://github.com/AxmeAI/axme-sdk-python) | Python SDK used by Python examples |
-| [axme-sdk-typescript](https://github.com/AxmeAI/axme-sdk-typescript) | TypeScript SDK |
-| [axme-sdk-go](https://github.com/AxmeAI/axme-sdk-go) | Go SDK |
-| [axme-sdk-java](https://github.com/AxmeAI/axme-sdk-java) | Java SDK |
-| [axme-sdk-dotnet](https://github.com/AxmeAI/axme-sdk-dotnet) | .NET SDK |
-| [axme-reference-clients](https://github.com/AxmeAI/axme-reference-clients) | Full reference application implementations |
+| [axme-docs](https://github.com/AxmeAI/axme-docs) | API and integration docs |
+| [axme-sdk-python](https://github.com/AxmeAI/axme-sdk-python) | Python SDK used by examples |
+| [axme-sdk-typescript](https://github.com/AxmeAI/axme-sdk-typescript) | TypeScript SDK used by examples |
+| [axme-sdk-go](https://github.com/AxmeAI/axme-sdk-go) | Go SDK snippets |
+| [axme-sdk-java](https://github.com/AxmeAI/axme-sdk-java) | Java SDK snippets |
+| [axme-sdk-dotnet](https://github.com/AxmeAI/axme-sdk-dotnet) | .NET SDK snippets |
 
----
+## Contributing
 
-## Contributing & Contact
-
-- Suggest an example: open an issue with label `example-request`
-- Alpha access: https://cloud.axme.ai/alpha · Contact and suggestions: [hello@axme.ai](mailto:hello@axme.ai)
-- Security disclosures: see [SECURITY.md](SECURITY.md)
-- Contribution guidelines: [CONTRIBUTING.md](CONTRIBUTING.md)
+- Suggest a new scenario with `example-request` issue label.
+- Keep examples use-case-first and runnable end-to-end.
+- Keep Cloud and Protocol examples explicitly separated.
+- Keep tracked files in English.

--- a/cloud/README.md
+++ b/cloud/README.md
@@ -1,0 +1,31 @@
+# Cloud Examples Index
+
+These examples require AXME Cloud runtime and an API key.
+
+Use this path for product onboarding and lifecycle orchestration scenarios:
+
+- durable execution
+- retries and backoff
+- callbacks and multi-service coordination
+- workflow controls and runtime lifecycle events
+
+## Canonical runnable set
+
+- `../examples/approval-workflow`
+- `../examples/external-callback`
+- `../examples/retry-workflow`
+- `../examples/multi-service-coordination`
+
+Cloud aliases (stable path layout, no code duplication):
+
+- `approval-workflow/`
+- `external-callback/`
+- `retry-workflow/`
+- `multi-service-coordination/`
+
+## Requirements
+
+- `AXME_API_KEY` (service-account key from `https://cloud.axme.ai/alpha`)
+- optional `AXME_BASE_URL` override (default `https://api.cloud.axme.ai`)
+
+For protocol-only examples that do not require AXME Cloud, see `../protocol/README.md`.

--- a/cloud/approval-workflow/README.md
+++ b/cloud/approval-workflow/README.md
@@ -1,0 +1,7 @@
+# Cloud Example Alias: approval-workflow
+
+Canonical runnable source:
+
+- `../../examples/approval-workflow`
+
+This alias path exists to keep a clear `cloud/*` layout without duplicating runnable code.

--- a/cloud/external-callback/README.md
+++ b/cloud/external-callback/README.md
@@ -1,0 +1,7 @@
+# Cloud Example Alias: external-callback
+
+Canonical runnable source:
+
+- `../../examples/external-callback`
+
+This alias path exists to keep a clear `cloud/*` layout without duplicating runnable code.

--- a/cloud/multi-service-coordination/README.md
+++ b/cloud/multi-service-coordination/README.md
@@ -1,0 +1,7 @@
+# Cloud Example Alias: multi-service-coordination
+
+Canonical runnable source:
+
+- `../../examples/multi-service-coordination`
+
+This alias path exists to keep a clear `cloud/*` layout without duplicating runnable code.

--- a/cloud/retry-workflow/README.md
+++ b/cloud/retry-workflow/README.md
@@ -1,0 +1,7 @@
+# Cloud Example Alias: retry-workflow
+
+Canonical runnable source:
+
+- `../../examples/retry-workflow`
+
+This alias path exists to keep a clear `cloud/*` layout without duplicating runnable code.

--- a/docs/example-matrix.md
+++ b/docs/example-matrix.md
@@ -1,0 +1,31 @@
+# Example Matrix
+
+This repository contains two example families:
+
+- **Cloud examples**: runnable orchestration scenarios (require AXME Cloud)
+- **Protocol examples**: AXP-only compatibility scenarios (no AXME Cloud runtime required)
+
+## Cloud matrix
+
+All cloud scenarios require API key from the landing page.
+`AXME_BASE_URL` can be used as an optional override for staging/dev.
+
+| Scenario | Python | TypeScript | Go | Java | .NET |
+|---|---|---|---|---|---|
+| approval-workflow | full | full | snippet | snippet | snippet |
+| external-callback | full | full | snippet | snippet | snippet |
+| retry-workflow | full | full | snippet | snippet | snippet |
+| multi-service-coordination | full | full | snippet | snippet | snippet |
+
+Legend:
+
+- `full`: runnable project in `examples/<scenario>/<language>`
+- `snippet`: short usage sample in `snippets/README.md`
+
+## Protocol matrix
+
+| Scenario | Runtime requirement | Purpose |
+|---|---|---|
+| `protocol/create-intent` | none | Intent payload/contract baseline |
+| `protocol/minimal-axp-service` | none | Minimal AXP-compatible lifecycle service |
+| `protocol/conformance-runner` | none | Validate custom implementation with conformance |

--- a/docs/landing-approval-snippet.md
+++ b/docs/landing-approval-snippet.md
@@ -1,0 +1,28 @@
+# Landing Example: Approval Flow
+
+Use this as the primary landing-page code block. It shows the core AXME value in seconds:
+
+`submit intent -> auto-approve -> COMPLETED`
+
+Get API key on the landing page: <https://cloud.axme.ai/alpha>
+
+Notes:
+
+- In landing snippets, do not show `baseUrl`; SDK default points to AXME Cloud.
+- `AXME_API_KEY` value is a service-account key (`axme_sa_...`) sent as `x-api-key`.
+
+```ts
+const client = new AxmeClient({ apiKey: process.env.AXME_API_KEY! });
+
+const created = await client.createIntent({ intent_type: "intent.approval.demo.v1" });
+await client.resumeIntent(created.intent_id, { approve_current_step: true });
+await client.resolveIntent(created.intent_id, { status: "COMPLETED" });
+```
+
+```text
+submit -> AUTO_APPROVED -> COMPLETED
+```
+
+Production note for landing copy:
+
+AXME Cloud currently provides the runtime for executing intents. Public repositories include the protocol, SDKs, CLI, conformance tests, docs, and integration examples.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,26 @@
+# Example Catalog
+
+Use-case-first canonical **Cloud runtime** examples:
+
+1. `approval-workflow`
+2. `external-callback`
+3. `retry-workflow`
+4. `multi-service-coordination`
+
+Each scenario includes:
+
+- `.env.example`
+- `README.md`
+- `python/` runnable flow
+- `typescript/` runnable flow
+
+All examples in this directory run against **AXME Cloud** and require an API key from the landing page.
+Get API key: <https://cloud.axme.ai/alpha>
+
+Environment model:
+
+- `AXME_API_KEY` - required
+- `AXME_BASE_URL` - optional; defaults to AXME Cloud endpoint
+
+For protocol-only examples without AXME Cloud runtime, see [`../protocol/README.md`](../protocol/README.md).
+For Go/Java/.NET usage snippets, see [`../snippets/README.md`](../snippets/README.md).

--- a/examples/approval-workflow/.env.example
+++ b/examples/approval-workflow/.env.example
@@ -1,0 +1,9 @@
+# Optional override. If omitted, example uses AXME Cloud default endpoint.
+AXME_BASE_URL=https://api.cloud.axme.ai
+AXME_API_KEY=replace-with-api-key
+# Optional for routes requiring actor context.
+AXME_ACTOR_TOKEN=
+
+AXME_FROM_AGENT=agent://examples/requester
+AXME_TO_AGENT=agent://examples/approver
+AXME_APPROVAL_OWNER_AGENT=agent://examples/requester

--- a/examples/approval-workflow/README.md
+++ b/examples/approval-workflow/README.md
@@ -1,0 +1,73 @@
+# Approval Workflow
+
+Problem: your operation requires approval semantics, but the product path must stay fast.  
+Goal: keep one durable intent lifecycle and finish without losing state.
+
+This example demonstrates:
+
+- intent creation (`POST /v1/intents`)
+- automatic approval via immediate `resume`
+- terminal completion via `resolve`
+- lifecycle event observation
+
+## Requirements
+
+This example runs against **AXME Cloud**.
+
+You need:
+
+- AXME Cloud API key (generated on the landing page)
+- `.env` file with `AXME_API_KEY` set (copy from `.env.example`)
+- optional `AXME_BASE_URL` override (defaults to AXME Cloud endpoint)
+
+Get API key at:
+
+- <https://cloud.axme.ai/alpha>
+
+```mermaid
+sequenceDiagram
+    participant App as Client App
+    participant AXME as AXME Cloud Runtime
+
+    App->>AXME: create intent
+    App->>AXME: resume intent (auto-approved, no manual wait)
+    App->>AXME: resolve COMPLETED
+    AXME-->>App: terminal lifecycle event
+```
+
+## Run (Python)
+
+```bash
+cd examples/approval-workflow/python
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+cp ../.env.example ../.env
+# edit ../.env and set AXME_API_KEY
+# optional override:
+# export AXME_BASE_URL="https://api.cloud.axme.ai"
+python main.py
+```
+
+## Run (TypeScript)
+
+```bash
+cd examples/approval-workflow/typescript
+npm install
+cp ../.env.example ../.env
+# edit ../.env and set AXME_API_KEY
+# optional override:
+# export AXME_BASE_URL="https://api.cloud.axme.ai"
+npm run start
+```
+
+## Notes
+
+- This scenario is configured as an automatic approval path.
+- The example does not wait for manual/human approval.
+
+## Additional SDK snippets
+
+See [`../../snippets/README.md`](../../snippets/README.md).
+
+Built using AXME (AXP).

--- a/examples/approval-workflow/python/main.py
+++ b/examples/approval-workflow/python/main.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from dotenv import load_dotenv
+
+from axme import AxmeClient, AxmeClientConfig
+
+
+def _require_env(name: str) -> str:
+    value = os.getenv(name, "").strip()
+    if not value:
+        raise RuntimeError(f"missing required env var: {name}")
+    return value
+
+
+def _print_events(events: list[dict[str, Any]]) -> None:
+    for event in events:
+        seq = int(event.get("seq", 0))
+        status = str(event.get("status", "unknown"))
+        event_type = str(event.get("event_type", "unknown"))
+        waiting_reason = event.get("waiting_reason")
+        suffix = f" waiting_reason={waiting_reason}" if waiting_reason else ""
+        print(f"[event] seq={seq} type={event_type} status={status}{suffix}")
+
+
+def main() -> None:
+    load_dotenv(Path(__file__).resolve().parent.parent / ".env")
+
+    base_url = os.getenv("AXME_BASE_URL", "https://api.cloud.axme.ai").strip()
+    api_key = _require_env("AXME_API_KEY")
+    actor_token = os.getenv("AXME_ACTOR_TOKEN", "").strip() or None
+    from_agent = os.getenv("AXME_FROM_AGENT", "agent://examples/requester").strip()
+    to_agent = os.getenv("AXME_TO_AGENT", "agent://examples/approver").strip()
+    owner_agent = os.getenv("AXME_APPROVAL_OWNER_AGENT", from_agent).strip()
+
+    config = AxmeClientConfig(base_url=base_url, api_key=api_key, actor_token=actor_token)
+
+    correlation_id = str(uuid4())
+    idempotency_key = f"approval-{correlation_id}"
+
+    intent_payload = {
+        "intent_type": "intent.approval.demo.v1",
+        "correlation_id": correlation_id,
+        "from_agent": from_agent,
+        "to_agent": to_agent,
+        "payload": {
+            "request_id": f"req-{correlation_id[:8]}",
+            "summary": "Auto-approved rollout request.",
+            "requested_by": from_agent,
+            "approval_mode": "automatic",
+        },
+    }
+
+    with AxmeClient(config) as client:
+        created = client.create_intent(
+            intent_payload,
+            correlation_id=correlation_id,
+            idempotency_key=idempotency_key,
+        )
+        intent_id = str(created["intent_id"])
+        print(f"[create] intent_id={intent_id} status={created.get('status')}")
+        print("[approval] auto-approval path enabled; no manual waiting.")
+
+        resumed = client.resume_intent(
+            intent_id,
+            {
+                "approve_current_step": True,
+                "reason": "auto-approved by policy",
+            },
+            owner_agent=owner_agent,
+        )
+        print(
+            "[resume] "
+            f"applied={resumed.get('applied')} policy_generation={resumed.get('policy_generation')}"
+        )
+
+        resolved = client.resolve_intent(
+            intent_id,
+            {
+                "status": "COMPLETED",
+                "result": {
+                    "approval_result": "auto-approved",
+                    "approval_mode": "automatic",
+                },
+            },
+        )
+        terminal_event = resolved.get("event", {})
+        print(
+            f"[resolve] terminal_type={terminal_event.get('event_type')} "
+            f"status={terminal_event.get('status')}"
+        )
+
+        listed = client.list_intent_events(intent_id)
+        events = listed.get("events", [])
+        if isinstance(events, list):
+            normalized = [item for item in events if isinstance(item, dict)]
+            _print_events(normalized)
+
+        final_intent = client.get_intent(intent_id).get("intent", {})
+        print(
+            f"[final] intent_id={intent_id} status={final_intent.get('status')} "
+            f"lifecycle_status={final_intent.get('lifecycle_status')}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/approval-workflow/python/requirements.txt
+++ b/examples/approval-workflow/python/requirements.txt
@@ -1,0 +1,2 @@
+axme>=0.1.1
+python-dotenv>=1.0.1

--- a/examples/approval-workflow/typescript/main.ts
+++ b/examples/approval-workflow/typescript/main.ts
@@ -1,0 +1,103 @@
+import { config as loadEnv } from "dotenv";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { AxmeClient } from "@axme/axme/dist/src/index.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+loadEnv({ path: path.resolve(__dirname, "..", ".env") });
+
+function requireEnv(name: string): string {
+  const value = (process.env[name] ?? "").trim();
+  if (!value) {
+    throw new Error(`missing required env var: ${name}`);
+  }
+  return value;
+}
+
+function printEvents(events: Array<Record<string, unknown>>): void {
+  for (const event of events) {
+    const seq = typeof event.seq === "number" ? event.seq : 0;
+    const eventType = String(event.event_type ?? "unknown");
+    const status = String(event.status ?? "unknown");
+    const waitingReason = event.waiting_reason ? ` waiting_reason=${String(event.waiting_reason)}` : "";
+    console.log(`[event] seq=${seq} type=${eventType} status=${status}${waitingReason}`);
+  }
+}
+
+async function main(): Promise<void> {
+  const baseUrl = (process.env.AXME_BASE_URL ?? "https://api.cloud.axme.ai").trim();
+  const apiKey = requireEnv("AXME_API_KEY");
+  const actorToken = (process.env.AXME_ACTOR_TOKEN ?? "").trim() || undefined;
+  const fromAgent = (process.env.AXME_FROM_AGENT ?? "agent://examples/requester").trim();
+  const toAgent = (process.env.AXME_TO_AGENT ?? "agent://examples/approver").trim();
+  const ownerAgent = (process.env.AXME_APPROVAL_OWNER_AGENT ?? fromAgent).trim();
+
+  const client = new AxmeClient({
+    baseUrl,
+    apiKey,
+    actorToken,
+  });
+
+  const correlationId = crypto.randomUUID();
+  const idempotencyKey = `approval-${correlationId}`;
+  const payload = {
+    intent_type: "intent.approval.demo.v1",
+    correlation_id: correlationId,
+    from_agent: fromAgent,
+    to_agent: toAgent,
+    payload: {
+      request_id: `req-${correlationId.slice(0, 8)}`,
+      summary: "Auto-approved rollout request.",
+      requested_by: fromAgent,
+      approval_mode: "automatic",
+    },
+  };
+
+  const created = await client.createIntent(payload, {
+    correlationId,
+    idempotencyKey,
+  });
+  const intentId = String(created.intent_id);
+  console.log(`[create] intent_id=${intentId} status=${String(created.status ?? "unknown")}`);
+  console.log("[approval] auto-approval path enabled; no manual waiting.");
+
+  const resumed = await client.resumeIntent(
+    intentId,
+    {
+      approve_current_step: true,
+      reason: "auto-approved by policy",
+    },
+    { ownerAgent },
+  );
+  console.log(
+    `[resume] applied=${String(resumed.applied ?? "unknown")} policy_generation=${String(resumed.policy_generation ?? "unknown")}`,
+  );
+
+  const resolved = await client.resolveIntent(intentId, {
+    status: "COMPLETED",
+    result: {
+      approval_result: "auto-approved",
+      approval_mode: "automatic",
+    },
+  });
+  const terminalEvent = (resolved.event ?? {}) as Record<string, unknown>;
+  console.log(`[resolve] terminal_type=${String(terminalEvent.event_type ?? "unknown")} status=${String(terminalEvent.status ?? "unknown")}`);
+
+  const listed = await client.listIntentEvents(intentId);
+  const events = Array.isArray(listed.events)
+    ? listed.events.filter((item): item is Record<string, unknown> => Boolean(item) && typeof item === "object")
+    : [];
+  printEvents(events);
+
+  const finalIntent = ((await client.getIntent(intentId)).intent ?? {}) as Record<string, unknown>;
+  console.log(
+    `[final] intent_id=${intentId} status=${String(finalIntent.status ?? "unknown")} lifecycle_status=${String(finalIntent.lifecycle_status ?? "unknown")}`,
+  );
+}
+
+main().catch((error) => {
+  console.error("[error]", error);
+  process.exit(1);
+});

--- a/examples/approval-workflow/typescript/package-lock.json
+++ b/examples/approval-workflow/typescript/package-lock.json
@@ -1,0 +1,160 @@
+{
+  "name": "axme-example-approval-workflow-ts",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "axme-example-approval-workflow-ts",
+      "dependencies": {
+        "@axme/axme": "^0.1.1",
+        "dotenv": "^16.4.5"
+      },
+      "devDependencies": {
+        "@types/node": "^25.3.5",
+        "tsx": "^4.20.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@axme/axme": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@axme/axme/-/axme-0.1.1.tgz",
+      "integrity": "sha512-mbUKRWx1n37yyivGaMLS/z7+WF6Pnl//LvCCJCVQCpQ3+yO5yOJ4FafGWjqTb0AKkDmdbD1bytJSameQYfn34Q==",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.3.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.5.tgz",
+      "integrity": "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.6",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/examples/approval-workflow/typescript/package.json
+++ b/examples/approval-workflow/typescript/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "axme-example-approval-workflow-ts",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx main.ts"
+  },
+  "dependencies": {
+    "@axme/axme": "^0.1.1",
+    "dotenv": "^16.4.5"
+  },
+  "devDependencies": {
+    "@types/node": "^25.3.5",
+    "tsx": "^4.20.0"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/examples/approval-workflow/typescript/tsconfig.json
+++ b/examples/approval-workflow/typescript/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "types": [
+      "node"
+    ],
+    "lib": [
+      "ES2022"
+    ],
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "main.ts"
+  ]
+}

--- a/examples/external-callback/.env.example
+++ b/examples/external-callback/.env.example
@@ -1,0 +1,14 @@
+# Optional override. If omitted, example uses AXME Cloud default endpoint.
+AXME_BASE_URL=https://api.cloud.axme.ai
+AXME_API_KEY=replace-with-api-key
+# Optional for routes requiring actor context.
+AXME_ACTOR_TOKEN=
+
+AXME_FROM_AGENT=agent://examples/orchestrator
+AXME_TO_AGENT=agent://examples/external-worker
+AXME_OWNER_AGENT=agent://examples/orchestrator
+
+AXME_CALLBACK_HOST=127.0.0.1
+AXME_CALLBACK_PORT=8787
+AXME_CALLBACK_TIMEOUT_SECONDS=30
+AXME_SIMULATE_CALLBACK=true

--- a/examples/external-callback/README.md
+++ b/examples/external-callback/README.md
@@ -1,0 +1,72 @@
+# External Callback
+
+Problem: your flow waits for an external provider callback (payments, KYC, report generation).  
+Goal: resume and complete one intent lifecycle when callback data arrives.
+
+This example demonstrates:
+
+- intent creation
+- waiting for callback data
+- callback-triggered `resume`
+- terminal `resolve` with callback payload
+
+## Requirements
+
+This example runs against **AXME Cloud**.
+
+You need:
+
+- AXME Cloud API key (generated on the landing page)
+- `.env` file with `AXME_API_KEY` set (copy from `.env.example`)
+- optional `AXME_BASE_URL` override (defaults to AXME Cloud endpoint)
+
+Get API key at:
+
+- <https://cloud.axme.ai/alpha>
+
+```mermaid
+sequenceDiagram
+    participant App as Client App
+    participant AXME as AXME Cloud Runtime
+    participant Ext as External System
+
+    App->>AXME: create intent
+    App->>Ext: start external operation
+    Ext-->>App: HTTP callback (event payload)
+    App->>AXME: resume intent
+    App->>AXME: resolve COMPLETED (with callback result)
+    AXME-->>App: terminal lifecycle event
+```
+
+## Run (Python)
+
+```bash
+cd examples/external-callback/python
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+cp ../.env.example ../.env
+# edit ../.env and set AXME_API_KEY
+# optional override:
+# export AXME_BASE_URL="https://api.cloud.axme.ai"
+python main.py
+```
+
+## Run (TypeScript)
+
+```bash
+cd examples/external-callback/typescript
+npm install
+cp ../.env.example ../.env
+# edit ../.env and set AXME_API_KEY
+# optional override:
+# export AXME_BASE_URL="https://api.cloud.axme.ai"
+npm run start
+```
+
+## Notes
+
+- By default, the script simulates an external callback (`AXME_SIMULATE_CALLBACK=true`).
+- To test a real callback path, set `AXME_SIMULATE_CALLBACK=false` and `POST` JSON to the callback endpoint printed by the script.
+
+Built using AXME (AXP).

--- a/examples/external-callback/python/main.py
+++ b/examples/external-callback/python/main.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import json
+import os
+import queue
+import threading
+import time
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from dotenv import load_dotenv
+
+from axme import AxmeClient, AxmeClientConfig
+
+
+def _require_env(name: str) -> str:
+    value = os.getenv(name, "").strip()
+    if not value:
+        raise RuntimeError(f"missing required env var: {name}")
+    return value
+
+
+def _as_int(name: str, default: int) -> int:
+    raw = os.getenv(name, "").strip()
+    if not raw:
+        return default
+    return int(raw)
+
+
+def _as_bool(name: str, default: bool) -> bool:
+    raw = os.getenv(name, "").strip().lower()
+    if not raw:
+        return default
+    return raw in {"1", "true", "yes", "on"}
+
+
+def _simulate_callback(callback_url: str, delay_seconds: int) -> None:
+    time.sleep(max(0, delay_seconds))
+    payload = {
+        "provider": "billing-gateway",
+        "callback_status": "approved",
+        "external_reference": f"ext-{uuid4().hex[:10]}",
+        "amount_cents": 4999,
+    }
+    request = urllib.request.Request(
+        callback_url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"content-type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=10):
+        pass
+
+
+def main() -> None:
+    load_dotenv(Path(__file__).resolve().parent.parent / ".env")
+
+    base_url = os.getenv("AXME_BASE_URL", "https://api.cloud.axme.ai").strip()
+    api_key = _require_env("AXME_API_KEY")
+    actor_token = os.getenv("AXME_ACTOR_TOKEN", "").strip() or None
+    from_agent = os.getenv("AXME_FROM_AGENT", "agent://examples/orchestrator").strip()
+    to_agent = os.getenv("AXME_TO_AGENT", "agent://examples/external-worker").strip()
+    owner_agent = os.getenv("AXME_OWNER_AGENT", from_agent).strip()
+    callback_host = os.getenv("AXME_CALLBACK_HOST", "127.0.0.1").strip()
+    callback_port = _as_int("AXME_CALLBACK_PORT", 8787)
+    callback_timeout = _as_int("AXME_CALLBACK_TIMEOUT_SECONDS", 30)
+    simulate_callback = _as_bool("AXME_SIMULATE_CALLBACK", True)
+
+    callback_queue: queue.Queue[dict[str, Any]] = queue.Queue(maxsize=1)
+
+    class CallbackHandler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:  # noqa: N802 (built-in handler contract)
+            content_length = int(self.headers.get("content-length", "0"))
+            raw_body = self.rfile.read(content_length) if content_length > 0 else b"{}"
+            try:
+                payload = json.loads(raw_body.decode("utf-8"))
+            except ValueError:
+                payload = {"raw": raw_body.decode("utf-8", errors="replace")}
+            try:
+                callback_queue.put_nowait(payload if isinstance(payload, dict) else {"payload": payload})
+            except queue.Full:
+                pass
+            self.send_response(200)
+            self.send_header("content-type", "application/json")
+            self.end_headers()
+            self.wfile.write(b'{"ok": true}')
+
+        def log_message(self, format: str, *args: Any) -> None:  # noqa: A003
+            return
+
+    server = ThreadingHTTPServer((callback_host, callback_port), CallbackHandler)
+    server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+    server_thread.start()
+    callback_url = f"http://{callback_host}:{callback_port}/external/callback"
+    print(f"[callback] listening on {callback_url}")
+
+    if simulate_callback:
+        threading.Thread(target=_simulate_callback, args=(callback_url, 2), daemon=True).start()
+        print("[callback] simulation enabled; callback will be posted automatically.")
+
+    config = AxmeClientConfig(base_url=base_url, api_key=api_key, actor_token=actor_token)
+    correlation_id = str(uuid4())
+    idempotency_key = f"external-callback-{correlation_id}"
+    intent_payload = {
+        "intent_type": "intent.external_callback.demo.v1",
+        "correlation_id": correlation_id,
+        "from_agent": from_agent,
+        "to_agent": to_agent,
+        "payload": {
+            "operation": "capture_payment",
+            "order_id": f"order-{correlation_id[:8]}",
+            "callback_url": callback_url,
+        },
+    }
+
+    try:
+        with AxmeClient(config) as client:
+            created = client.create_intent(
+                intent_payload,
+                correlation_id=correlation_id,
+                idempotency_key=idempotency_key,
+            )
+            intent_id = str(created["intent_id"])
+            print(f"[create] intent_id={intent_id} status={created.get('status')}")
+
+            print(f"[callback] waiting up to {callback_timeout}s for external payload...")
+            callback_payload = callback_queue.get(timeout=callback_timeout)
+            print(f"[callback] received: {json.dumps(callback_payload, ensure_ascii=True)}")
+
+            resumed = client.resume_intent(
+                intent_id,
+                {
+                    "approve_current_step": True,
+                    "reason": "external callback received",
+                },
+                owner_agent=owner_agent,
+            )
+            print(f"[resume] applied={resumed.get('applied')} policy_generation={resumed.get('policy_generation')}")
+
+            resolved = client.resolve_intent(
+                intent_id,
+                {
+                    "status": "COMPLETED",
+                    "result": {
+                        "source": "external_callback",
+                        "callback_payload": callback_payload,
+                    },
+                },
+            )
+            event = resolved.get("event", {})
+            print(f"[resolve] event_type={event.get('event_type')} status={event.get('status')}")
+
+            final_intent = client.get_intent(intent_id).get("intent", {})
+            print(
+                f"[final] intent_id={intent_id} status={final_intent.get('status')} "
+                f"lifecycle_status={final_intent.get('lifecycle_status')}"
+            )
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/external-callback/python/requirements.txt
+++ b/examples/external-callback/python/requirements.txt
@@ -1,0 +1,2 @@
+axme>=0.1.1
+python-dotenv>=1.0.1

--- a/examples/external-callback/typescript/main.ts
+++ b/examples/external-callback/typescript/main.ts
@@ -1,0 +1,154 @@
+import { config as loadEnv } from "dotenv";
+import http from "node:http";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { AxmeClient } from "@axme/axme/dist/src/index.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+loadEnv({ path: path.resolve(__dirname, "..", ".env") });
+
+function requireEnv(name: string): string {
+  const value = (process.env[name] ?? "").trim();
+  if (!value) {
+    throw new Error(`missing required env var: ${name}`);
+  }
+  return value;
+}
+
+function asInt(name: string, fallback: number): number {
+  const raw = (process.env[name] ?? "").trim();
+  if (!raw) {
+    return fallback;
+  }
+  return Number.parseInt(raw, 10);
+}
+
+function asBool(name: string, fallback: boolean): boolean {
+  const raw = (process.env[name] ?? "").trim().toLowerCase();
+  if (!raw) {
+    return fallback;
+  }
+  return ["1", "true", "yes", "on"].includes(raw);
+}
+
+async function simulateCallback(callbackUrl: string, delaySeconds: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, Math.max(0, delaySeconds) * 1000));
+  const payload = {
+    provider: "billing-gateway",
+    callback_status: "approved",
+    external_reference: `ext-${crypto.randomUUID().slice(0, 8)}`,
+    amount_cents: 4999,
+  };
+  await fetch(callbackUrl, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+}
+
+async function main(): Promise<void> {
+  const baseUrl = (process.env.AXME_BASE_URL ?? "https://api.cloud.axme.ai").trim();
+  const apiKey = requireEnv("AXME_API_KEY");
+  const actorToken = (process.env.AXME_ACTOR_TOKEN ?? "").trim() || undefined;
+  const fromAgent = (process.env.AXME_FROM_AGENT ?? "agent://examples/orchestrator").trim();
+  const toAgent = (process.env.AXME_TO_AGENT ?? "agent://examples/external-worker").trim();
+  const ownerAgent = (process.env.AXME_OWNER_AGENT ?? fromAgent).trim();
+  const callbackHost = (process.env.AXME_CALLBACK_HOST ?? "127.0.0.1").trim();
+  const callbackPort = asInt("AXME_CALLBACK_PORT", 8787);
+  const callbackTimeoutSeconds = asInt("AXME_CALLBACK_TIMEOUT_SECONDS", 30);
+  const simulate = asBool("AXME_SIMULATE_CALLBACK", true);
+
+  const callbackPath = "/external/callback";
+  const callbackUrl = `http://${callbackHost}:${callbackPort}${callbackPath}`;
+  console.log(`[callback] listening on ${callbackUrl}`);
+
+  const callbackPayloadPromise = new Promise<Record<string, unknown>>((resolve, reject) => {
+    const timeout = setTimeout(
+      () => reject(new Error(`timed out waiting for callback after ${callbackTimeoutSeconds}s`)),
+      callbackTimeoutSeconds * 1000,
+    );
+    const server = http.createServer((req, res) => {
+      if (req.method !== "POST" || req.url !== callbackPath) {
+        res.writeHead(404).end();
+        return;
+      }
+      const chunks: Buffer[] = [];
+      req.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+      req.on("end", () => {
+        clearTimeout(timeout);
+        let parsed: unknown = {};
+        try {
+          parsed = JSON.parse(Buffer.concat(chunks).toString("utf-8"));
+        } catch {
+          parsed = { raw: Buffer.concat(chunks).toString("utf-8") };
+        }
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ ok: true }));
+        server.close();
+        resolve((parsed ?? {}) as Record<string, unknown>);
+      });
+    });
+    server.on("error", reject);
+    server.listen(callbackPort, callbackHost);
+  });
+
+  if (simulate) {
+    console.log("[callback] simulation enabled; callback will be posted automatically.");
+    void simulateCallback(callbackUrl, 2);
+  }
+
+  const client = new AxmeClient({ baseUrl, apiKey, actorToken });
+  const correlationId = crypto.randomUUID();
+  const idempotencyKey = `external-callback-${correlationId}`;
+  const payload = {
+    intent_type: "intent.external_callback.demo.v1",
+    correlation_id: correlationId,
+    from_agent: fromAgent,
+    to_agent: toAgent,
+    payload: {
+      operation: "capture_payment",
+      order_id: `order-${correlationId.slice(0, 8)}`,
+      callback_url: callbackUrl,
+    },
+  };
+
+  const created = await client.createIntent(payload, { correlationId, idempotencyKey });
+  const intentId = String(created.intent_id);
+  console.log(`[create] intent_id=${intentId} status=${String(created.status ?? "unknown")}`);
+
+  const callbackPayload = await callbackPayloadPromise;
+  console.log(`[callback] received: ${JSON.stringify(callbackPayload)}`);
+
+  const resumed = await client.resumeIntent(
+    intentId,
+    {
+      approve_current_step: true,
+      reason: "external callback received",
+    },
+    { ownerAgent },
+  );
+  console.log(`[resume] applied=${String(resumed.applied ?? "unknown")} policy_generation=${String(resumed.policy_generation ?? "unknown")}`);
+
+  const resolved = await client.resolveIntent(intentId, {
+    status: "COMPLETED",
+    result: {
+      source: "external_callback",
+      callback_payload: callbackPayload,
+    },
+  });
+  const event = (resolved.event ?? {}) as Record<string, unknown>;
+  console.log(`[resolve] event_type=${String(event.event_type ?? "unknown")} status=${String(event.status ?? "unknown")}`);
+
+  const finalIntent = ((await client.getIntent(intentId)).intent ?? {}) as Record<string, unknown>;
+  console.log(
+    `[final] intent_id=${intentId} status=${String(finalIntent.status ?? "unknown")} lifecycle_status=${String(finalIntent.lifecycle_status ?? "unknown")}`,
+  );
+}
+
+main().catch((error) => {
+  console.error("[error]", error);
+  process.exit(1);
+});

--- a/examples/external-callback/typescript/package-lock.json
+++ b/examples/external-callback/typescript/package-lock.json
@@ -1,0 +1,160 @@
+{
+  "name": "axme-example-external-callback-ts",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "axme-example-external-callback-ts",
+      "dependencies": {
+        "@axme/axme": "^0.1.1",
+        "dotenv": "^16.4.5"
+      },
+      "devDependencies": {
+        "@types/node": "^25.3.5",
+        "tsx": "^4.20.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@axme/axme": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@axme/axme/-/axme-0.1.1.tgz",
+      "integrity": "sha512-mbUKRWx1n37yyivGaMLS/z7+WF6Pnl//LvCCJCVQCpQ3+yO5yOJ4FafGWjqTb0AKkDmdbD1bytJSameQYfn34Q==",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.3.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.5.tgz",
+      "integrity": "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.6",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/examples/external-callback/typescript/package.json
+++ b/examples/external-callback/typescript/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "axme-example-external-callback-ts",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx main.ts"
+  },
+  "dependencies": {
+    "@axme/axme": "^0.1.1",
+    "dotenv": "^16.4.5"
+  },
+  "devDependencies": {
+    "@types/node": "^25.3.5",
+    "tsx": "^4.20.0"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/examples/external-callback/typescript/tsconfig.json
+++ b/examples/external-callback/typescript/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "types": [
+      "node"
+    ],
+    "lib": [
+      "ES2022"
+    ],
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "main.ts"
+  ]
+}

--- a/examples/multi-service-coordination/.env.example
+++ b/examples/multi-service-coordination/.env.example
@@ -1,0 +1,11 @@
+# Optional override. If omitted, example uses AXME Cloud default endpoint.
+AXME_BASE_URL=https://api.cloud.axme.ai
+AXME_API_KEY=replace-with-api-key
+# Optional for routes requiring actor context.
+AXME_ACTOR_TOKEN=
+
+AXME_FROM_AGENT=agent://examples/coordinator
+AXME_OWNER_AGENT=agent://examples/coordinator
+AXME_PARENT_TO_AGENT=agent://examples/orchestrator-runtime
+AXME_SERVICE_B_AGENT=agent://examples/service-b
+AXME_SERVICE_C_AGENT=agent://examples/service-c

--- a/examples/multi-service-coordination/README.md
+++ b/examples/multi-service-coordination/README.md
@@ -1,0 +1,64 @@
+# Multi-Service Coordination
+
+Problem: one business operation requires multiple services and ordered completion.  
+Goal: keep one parent intent lifecycle while coordinating child service work.
+
+This example demonstrates:
+
+- parent intent for orchestration context
+- child intents for service B and service C
+- child completion aggregation
+- parent completion with merged result
+
+## Requirements
+
+This example runs against **AXME Cloud**.
+
+You need:
+
+- AXME Cloud API key (generated on the landing page)
+- `.env` file with `AXME_API_KEY` set (copy from `.env.example`)
+- optional `AXME_BASE_URL` override (defaults to AXME Cloud endpoint)
+
+Get API key at:
+
+- <https://cloud.axme.ai/alpha>
+
+```mermaid
+flowchart LR
+  A[Create parent intent] --> B[Create child intent: Service B]
+  A --> C[Create child intent: Service C]
+  B --> D[Resolve child B]
+  C --> E[Resolve child C]
+  D --> F[Aggregate child outcomes]
+  E --> F
+  F --> G[Resolve parent intent COMPLETED]
+```
+
+## Run (Python)
+
+```bash
+cd examples/multi-service-coordination/python
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+cp ../.env.example ../.env
+# edit ../.env and set AXME_API_KEY
+# optional override:
+# export AXME_BASE_URL="https://api.cloud.axme.ai"
+python main.py
+```
+
+## Run (TypeScript)
+
+```bash
+cd examples/multi-service-coordination/typescript
+npm install
+cp ../.env.example ../.env
+# edit ../.env and set AXME_API_KEY
+# optional override:
+# export AXME_BASE_URL="https://api.cloud.axme.ai"
+npm run start
+```
+
+Built using AXME (AXP).

--- a/examples/multi-service-coordination/python/main.py
+++ b/examples/multi-service-coordination/python/main.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from dotenv import load_dotenv
+
+from axme import AxmeClient, AxmeClientConfig
+
+
+def _require_env(name: str) -> str:
+    value = os.getenv(name, "").strip()
+    if not value:
+        raise RuntimeError(f"missing required env var: {name}")
+    return value
+
+
+def _create_child_intent(
+    client: AxmeClient,
+    *,
+    from_agent: str,
+    to_agent: str,
+    service_name: str,
+    parent_intent_id: str,
+) -> str:
+    correlation_id = str(uuid4())
+    body = {
+        "intent_type": "intent.service_step.demo.v1",
+        "correlation_id": correlation_id,
+        "from_agent": from_agent,
+        "to_agent": to_agent,
+        "payload": {
+            "service": service_name,
+            "parent_intent_id": parent_intent_id,
+            "task": f"run_{service_name}_step",
+        },
+    }
+    created = client.create_intent(
+        body,
+        correlation_id=correlation_id,
+        idempotency_key=f"child-{service_name}-{correlation_id}",
+    )
+    return str(created["intent_id"])
+
+
+def main() -> None:
+    load_dotenv(Path(__file__).resolve().parent.parent / ".env")
+
+    base_url = os.getenv("AXME_BASE_URL", "https://api.cloud.axme.ai").strip()
+    api_key = _require_env("AXME_API_KEY")
+    actor_token = os.getenv("AXME_ACTOR_TOKEN", "").strip() or None
+    from_agent = os.getenv("AXME_FROM_AGENT", "agent://examples/coordinator").strip()
+    owner_agent = os.getenv("AXME_OWNER_AGENT", from_agent).strip()
+    parent_to_agent = os.getenv("AXME_PARENT_TO_AGENT", "agent://examples/orchestrator-runtime").strip()
+    service_b_agent = os.getenv("AXME_SERVICE_B_AGENT", "agent://examples/service-b").strip()
+    service_c_agent = os.getenv("AXME_SERVICE_C_AGENT", "agent://examples/service-c").strip()
+
+    config = AxmeClientConfig(base_url=base_url, api_key=api_key, actor_token=actor_token)
+
+    with AxmeClient(config) as client:
+        parent_correlation = str(uuid4())
+        parent_payload = {
+            "intent_type": "intent.multi_service.demo.v1",
+            "correlation_id": parent_correlation,
+            "from_agent": from_agent,
+            "to_agent": parent_to_agent,
+            "payload": {
+                "operation": "provision_enterprise_workspace",
+                "steps": ["service_b", "service_c"],
+            },
+        }
+        parent = client.create_intent(
+            parent_payload,
+            correlation_id=parent_correlation,
+            idempotency_key=f"parent-{parent_correlation}",
+        )
+        parent_intent_id = str(parent["intent_id"])
+        print(f"[parent:create] intent_id={parent_intent_id} status={parent.get('status')}")
+
+        resumed_parent = client.resume_intent(
+            parent_intent_id,
+            {"approve_current_step": True, "reason": "start orchestration"},
+            owner_agent=owner_agent,
+        )
+        print(
+            "[parent:resume] "
+            f"applied={resumed_parent.get('applied')} policy_generation={resumed_parent.get('policy_generation')}"
+        )
+
+        child_b_id = _create_child_intent(
+            client,
+            from_agent=from_agent,
+            to_agent=service_b_agent,
+            service_name="service_b",
+            parent_intent_id=parent_intent_id,
+        )
+        child_c_id = _create_child_intent(
+            client,
+            from_agent=from_agent,
+            to_agent=service_c_agent,
+            service_name="service_c",
+            parent_intent_id=parent_intent_id,
+        )
+        print(f"[child:create] service_b_intent_id={child_b_id}")
+        print(f"[child:create] service_c_intent_id={child_c_id}")
+
+        child_b_result: dict[str, Any] = {
+            "service": "service_b",
+            "status": "done",
+            "artifact": f"artifact-{uuid4().hex[:8]}",
+        }
+        child_c_result: dict[str, Any] = {
+            "service": "service_c",
+            "status": "done",
+            "artifact": f"artifact-{uuid4().hex[:8]}",
+        }
+
+        client.resolve_intent(child_b_id, {"status": "COMPLETED", "result": child_b_result})
+        client.resolve_intent(child_c_id, {"status": "COMPLETED", "result": child_c_result})
+        print("[child:resolve] service_b=COMPLETED service_c=COMPLETED")
+
+        parent_result = {
+            "operation": "provision_enterprise_workspace",
+            "children": [
+                {"intent_id": child_b_id, "result": child_b_result},
+                {"intent_id": child_c_id, "result": child_c_result},
+            ],
+        }
+        resolved_parent = client.resolve_intent(
+            parent_intent_id,
+            {"status": "COMPLETED", "result": parent_result},
+        )
+        print(f"[parent:resolve] status={resolved_parent.get('event', {}).get('status')}")
+
+        final_parent = client.get_intent(parent_intent_id).get("intent", {})
+        print(
+            f"[final] parent_intent_id={parent_intent_id} status={final_parent.get('status')} "
+            f"lifecycle_status={final_parent.get('lifecycle_status')}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/multi-service-coordination/python/requirements.txt
+++ b/examples/multi-service-coordination/python/requirements.txt
@@ -1,0 +1,2 @@
+axme>=0.1.1
+python-dotenv>=1.0.1

--- a/examples/multi-service-coordination/typescript/main.ts
+++ b/examples/multi-service-coordination/typescript/main.ts
@@ -1,0 +1,143 @@
+import { config as loadEnv } from "dotenv";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { AxmeClient } from "@axme/axme/dist/src/index.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+loadEnv({ path: path.resolve(__dirname, "..", ".env") });
+
+function requireEnv(name: string): string {
+  const value = (process.env[name] ?? "").trim();
+  if (!value) {
+    throw new Error(`missing required env var: ${name}`);
+  }
+  return value;
+}
+
+async function createChildIntent(
+  client: AxmeClient,
+  options: {
+    fromAgent: string;
+    toAgent: string;
+    serviceName: string;
+    parentIntentId: string;
+  },
+): Promise<string> {
+  const correlationId = crypto.randomUUID();
+  const created = await client.createIntent(
+    {
+      intent_type: "intent.service_step.demo.v1",
+      correlation_id: correlationId,
+      from_agent: options.fromAgent,
+      to_agent: options.toAgent,
+      payload: {
+        service: options.serviceName,
+        parent_intent_id: options.parentIntentId,
+        task: `run_${options.serviceName}_step`,
+      },
+    },
+    {
+      correlationId,
+      idempotencyKey: `child-${options.serviceName}-${correlationId}`,
+    },
+  );
+  return String(created.intent_id);
+}
+
+async function main(): Promise<void> {
+  const baseUrl = (process.env.AXME_BASE_URL ?? "https://api.cloud.axme.ai").trim();
+  const apiKey = requireEnv("AXME_API_KEY");
+  const actorToken = (process.env.AXME_ACTOR_TOKEN ?? "").trim() || undefined;
+  const fromAgent = (process.env.AXME_FROM_AGENT ?? "agent://examples/coordinator").trim();
+  const ownerAgent = (process.env.AXME_OWNER_AGENT ?? fromAgent).trim();
+  const parentToAgent = (process.env.AXME_PARENT_TO_AGENT ?? "agent://examples/orchestrator-runtime").trim();
+  const serviceBAgent = (process.env.AXME_SERVICE_B_AGENT ?? "agent://examples/service-b").trim();
+  const serviceCAgent = (process.env.AXME_SERVICE_C_AGENT ?? "agent://examples/service-c").trim();
+
+  const client = new AxmeClient({ baseUrl, apiKey, actorToken });
+
+  const parentCorrelationId = crypto.randomUUID();
+  const parent = await client.createIntent(
+    {
+      intent_type: "intent.multi_service.demo.v1",
+      correlation_id: parentCorrelationId,
+      from_agent: fromAgent,
+      to_agent: parentToAgent,
+      payload: {
+        operation: "provision_enterprise_workspace",
+        steps: ["service_b", "service_c"],
+      },
+    },
+    {
+      correlationId: parentCorrelationId,
+      idempotencyKey: `parent-${parentCorrelationId}`,
+    },
+  );
+  const parentIntentId = String(parent.intent_id);
+  console.log(`[parent:create] intent_id=${parentIntentId} status=${String(parent.status ?? "unknown")}`);
+
+  const resumedParent = await client.resumeIntent(
+    parentIntentId,
+    { approve_current_step: true, reason: "start orchestration" },
+    { ownerAgent },
+  );
+  console.log(
+    `[parent:resume] applied=${String(resumedParent.applied ?? "unknown")} policy_generation=${String(resumedParent.policy_generation ?? "unknown")}`,
+  );
+
+  const childBId = await createChildIntent(client, {
+    fromAgent,
+    toAgent: serviceBAgent,
+    serviceName: "service_b",
+    parentIntentId,
+  });
+  const childCId = await createChildIntent(client, {
+    fromAgent,
+    toAgent: serviceCAgent,
+    serviceName: "service_c",
+    parentIntentId,
+  });
+  console.log(`[child:create] service_b_intent_id=${childBId}`);
+  console.log(`[child:create] service_c_intent_id=${childCId}`);
+
+  const childBResult = {
+    service: "service_b",
+    status: "done",
+    artifact: `artifact-${crypto.randomUUID().slice(0, 8)}`,
+  };
+  const childCResult = {
+    service: "service_c",
+    status: "done",
+    artifact: `artifact-${crypto.randomUUID().slice(0, 8)}`,
+  };
+
+  await client.resolveIntent(childBId, { status: "COMPLETED", result: childBResult });
+  await client.resolveIntent(childCId, { status: "COMPLETED", result: childCResult });
+  console.log("[child:resolve] service_b=COMPLETED service_c=COMPLETED");
+
+  const parentResolved = await client.resolveIntent(parentIntentId, {
+    status: "COMPLETED",
+    result: {
+      operation: "provision_enterprise_workspace",
+      children: [
+        { intent_id: childBId, result: childBResult },
+        { intent_id: childCId, result: childCResult },
+      ],
+    },
+  });
+  const parentEvent = (parentResolved.event ?? {}) as Record<string, unknown>;
+  console.log(`[parent:resolve] status=${String(parentEvent.status ?? "unknown")}`);
+
+  const finalParent = ((await client.getIntent(parentIntentId)).intent ?? {}) as Record<string, unknown>;
+  console.log(
+    `[final] parent_intent_id=${parentIntentId} status=${String(finalParent.status ?? "unknown")} lifecycle_status=${String(finalParent.lifecycle_status ?? "unknown")}`,
+  );
+}
+
+main().catch((error) => {
+  console.error("[error]", error);
+  process.exit(1);
+});

--- a/examples/multi-service-coordination/typescript/package-lock.json
+++ b/examples/multi-service-coordination/typescript/package-lock.json
@@ -1,0 +1,160 @@
+{
+  "name": "axme-example-multi-service-coordination-ts",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "axme-example-multi-service-coordination-ts",
+      "dependencies": {
+        "@axme/axme": "^0.1.1",
+        "dotenv": "^16.4.5"
+      },
+      "devDependencies": {
+        "@types/node": "^25.3.5",
+        "tsx": "^4.20.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@axme/axme": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@axme/axme/-/axme-0.1.1.tgz",
+      "integrity": "sha512-mbUKRWx1n37yyivGaMLS/z7+WF6Pnl//LvCCJCVQCpQ3+yO5yOJ4FafGWjqTb0AKkDmdbD1bytJSameQYfn34Q==",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.3.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.5.tgz",
+      "integrity": "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.6",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/examples/multi-service-coordination/typescript/package.json
+++ b/examples/multi-service-coordination/typescript/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "axme-example-multi-service-coordination-ts",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx main.ts"
+  },
+  "dependencies": {
+    "@axme/axme": "^0.1.1",
+    "dotenv": "^16.4.5"
+  },
+  "devDependencies": {
+    "@types/node": "^25.3.5",
+    "tsx": "^4.20.0"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/examples/multi-service-coordination/typescript/tsconfig.json
+++ b/examples/multi-service-coordination/typescript/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "types": [
+      "node"
+    ],
+    "lib": [
+      "ES2022"
+    ],
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "main.ts"
+  ]
+}

--- a/examples/retry-workflow/.env.example
+++ b/examples/retry-workflow/.env.example
@@ -1,0 +1,13 @@
+# Optional override. If omitted, example uses AXME Cloud default endpoint.
+AXME_BASE_URL=https://api.cloud.axme.ai
+AXME_API_KEY=replace-with-api-key
+# Optional for routes requiring actor context.
+AXME_ACTOR_TOKEN=
+
+AXME_FROM_AGENT=agent://examples/retry-orchestrator
+AXME_TO_AGENT=agent://examples/retry-worker
+AXME_OWNER_AGENT=agent://examples/retry-orchestrator
+
+AXME_MAX_ATTEMPTS=5
+AXME_SIMULATED_FAILURES=2
+AXME_BASE_BACKOFF_SECONDS=1

--- a/examples/retry-workflow/README.md
+++ b/examples/retry-workflow/README.md
@@ -1,0 +1,70 @@
+# Retry Workflow
+
+Problem: transient dependency failures should not lose operation state.  
+Goal: run retry with backoff while preserving one intent and one durable lifecycle.
+
+This example demonstrates:
+
+- idempotent intent creation
+- retry loop with exponential backoff
+- optional control updates between attempts
+- terminal completion after successful retry
+
+## Requirements
+
+This example runs against **AXME Cloud**.
+
+You need:
+
+- AXME Cloud API key (generated on the landing page)
+- `.env` file with `AXME_API_KEY` set (copy from `.env.example`)
+- optional `AXME_BASE_URL` override (defaults to AXME Cloud endpoint)
+
+Get API key at:
+
+- <https://cloud.axme.ai/alpha>
+
+```mermaid
+sequenceDiagram
+    participant App as Client App
+    participant AXME as AXME Cloud Runtime
+    participant Dep as External Dependency
+
+    App->>AXME: create intent (idempotency key)
+    loop Retry attempts
+        App->>Dep: execute step
+        Dep-->>App: transient failure
+        App->>AXME: update controls / keep lifecycle context
+    end
+    App->>Dep: execute step (success)
+    Dep-->>App: success payload
+    App->>AXME: resolve COMPLETED
+```
+
+## Run (Python)
+
+```bash
+cd examples/retry-workflow/python
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+cp ../.env.example ../.env
+# edit ../.env and set AXME_API_KEY
+# optional override:
+# export AXME_BASE_URL="https://api.cloud.axme.ai"
+python main.py
+```
+
+## Run (TypeScript)
+
+```bash
+cd examples/retry-workflow/typescript
+npm install
+cp ../.env.example ../.env
+# edit ../.env and set AXME_API_KEY
+# optional override:
+# export AXME_BASE_URL="https://api.cloud.axme.ai"
+npm run start
+```
+
+Built using AXME (AXP).

--- a/examples/retry-workflow/python/main.py
+++ b/examples/retry-workflow/python/main.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from dotenv import load_dotenv
+
+from axme import AxmeClient, AxmeClientConfig
+
+
+def _require_env(name: str) -> str:
+    value = os.getenv(name, "").strip()
+    if not value:
+        raise RuntimeError(f"missing required env var: {name}")
+    return value
+
+
+def _as_int(name: str, default: int) -> int:
+    raw = os.getenv(name, "").strip()
+    if not raw:
+        return default
+    return int(raw)
+
+
+def _run_external_step(attempt: int, *, simulated_failures: int) -> dict[str, Any]:
+    if attempt <= simulated_failures:
+        raise RuntimeError(f"transient dependency failure on attempt {attempt}")
+    return {
+        "status": "ok",
+        "attempt": attempt,
+        "job_reference": f"job-{uuid4().hex[:10]}",
+    }
+
+
+def main() -> None:
+    load_dotenv(Path(__file__).resolve().parent.parent / ".env")
+
+    base_url = os.getenv("AXME_BASE_URL", "https://api.cloud.axme.ai").strip()
+    api_key = _require_env("AXME_API_KEY")
+    actor_token = os.getenv("AXME_ACTOR_TOKEN", "").strip() or None
+    from_agent = os.getenv("AXME_FROM_AGENT", "agent://examples/retry-orchestrator").strip()
+    to_agent = os.getenv("AXME_TO_AGENT", "agent://examples/retry-worker").strip()
+    owner_agent = os.getenv("AXME_OWNER_AGENT", from_agent).strip()
+    max_attempts = _as_int("AXME_MAX_ATTEMPTS", 5)
+    simulated_failures = _as_int("AXME_SIMULATED_FAILURES", 2)
+    base_backoff_seconds = _as_int("AXME_BASE_BACKOFF_SECONDS", 1)
+
+    config = AxmeClientConfig(base_url=base_url, api_key=api_key, actor_token=actor_token)
+    correlation_id = str(uuid4())
+    idempotency_key = f"retry-{correlation_id}"
+    payload = {
+        "intent_type": "intent.retry.demo.v1",
+        "correlation_id": correlation_id,
+        "from_agent": from_agent,
+        "to_agent": to_agent,
+        "payload": {
+            "task": "sync_remote_inventory",
+            "target_system": "warehouse-api",
+        },
+    }
+
+    with AxmeClient(config) as client:
+        created_first = client.create_intent(payload, correlation_id=correlation_id, idempotency_key=idempotency_key)
+        created_second = client.create_intent(payload, correlation_id=correlation_id, idempotency_key=idempotency_key)
+        intent_id = str(created_first["intent_id"])
+        print(f"[create] intent_id={intent_id} status={created_first.get('status')}")
+        print(f"[idempotency] replay_intent_id={created_second.get('intent_id')}")
+
+        attempts = 0
+        delays: list[int] = []
+        external_result: dict[str, Any] | None = None
+
+        while attempts < max_attempts:
+            attempts += 1
+            try:
+                external_result = _run_external_step(attempts, simulated_failures=simulated_failures)
+                print(f"[attempt {attempts}] external step succeeded")
+                break
+            except RuntimeError as exc:
+                delay_seconds = base_backoff_seconds * (2 ** (attempts - 1))
+                delays.append(delay_seconds)
+                print(f"[attempt {attempts}] {exc}; backing off for {delay_seconds}s")
+                control_body = client.update_intent_controls(
+                    intent_id,
+                    {
+                        "controls_patch": {
+                            "last_retry_attempt": attempts,
+                            "next_retry_delay_seconds": delay_seconds,
+                        },
+                        "reason": f"retry attempt {attempts} failed",
+                    },
+                    owner_agent=owner_agent,
+                )
+                print(
+                    "[controls] "
+                    f"applied={control_body.get('applied')} policy_generation={control_body.get('policy_generation')}"
+                )
+                time.sleep(max(0, delay_seconds))
+
+        if external_result is not None:
+            resolved = client.resolve_intent(
+                intent_id,
+                {
+                    "status": "COMPLETED",
+                    "result": {
+                        "attempts": attempts,
+                        "retry_backoff_seconds": delays,
+                        "external_result": external_result,
+                    },
+                },
+            )
+            print(f"[resolve] status={resolved.get('event', {}).get('status')}")
+        else:
+            failed = client.resolve_intent(
+                intent_id,
+                {
+                    "status": "FAILED",
+                    "error": {
+                        "code": "max_attempts_exceeded",
+                        "attempts": attempts,
+                        "retry_backoff_seconds": delays,
+                    },
+                },
+            )
+            print(f"[resolve] status={failed.get('event', {}).get('status')}")
+
+        final_intent = client.get_intent(intent_id).get("intent", {})
+        print(
+            f"[final] intent_id={intent_id} status={final_intent.get('status')} "
+            f"lifecycle_status={final_intent.get('lifecycle_status')}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/retry-workflow/python/requirements.txt
+++ b/examples/retry-workflow/python/requirements.txt
@@ -1,0 +1,2 @@
+axme>=0.1.1
+python-dotenv>=1.0.1

--- a/examples/retry-workflow/typescript/main.ts
+++ b/examples/retry-workflow/typescript/main.ts
@@ -1,0 +1,135 @@
+import { config as loadEnv } from "dotenv";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { AxmeClient } from "@axme/axme/dist/src/index.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+loadEnv({ path: path.resolve(__dirname, "..", ".env") });
+
+function requireEnv(name: string): string {
+  const value = (process.env[name] ?? "").trim();
+  if (!value) {
+    throw new Error(`missing required env var: ${name}`);
+  }
+  return value;
+}
+
+function asInt(name: string, fallback: number): number {
+  const raw = (process.env[name] ?? "").trim();
+  if (!raw) {
+    return fallback;
+  }
+  return Number.parseInt(raw, 10);
+}
+
+function runExternalStep(attempt: number, simulatedFailures: number): Record<string, unknown> {
+  if (attempt <= simulatedFailures) {
+    throw new Error(`transient dependency failure on attempt ${attempt}`);
+  }
+  return {
+    status: "ok",
+    attempt,
+    job_reference: `job-${crypto.randomUUID().slice(0, 8)}`,
+  };
+}
+
+async function main(): Promise<void> {
+  const baseUrl = (process.env.AXME_BASE_URL ?? "https://api.cloud.axme.ai").trim();
+  const apiKey = requireEnv("AXME_API_KEY");
+  const actorToken = (process.env.AXME_ACTOR_TOKEN ?? "").trim() || undefined;
+  const fromAgent = (process.env.AXME_FROM_AGENT ?? "agent://examples/retry-orchestrator").trim();
+  const toAgent = (process.env.AXME_TO_AGENT ?? "agent://examples/retry-worker").trim();
+  const ownerAgent = (process.env.AXME_OWNER_AGENT ?? fromAgent).trim();
+  const maxAttempts = asInt("AXME_MAX_ATTEMPTS", 5);
+  const simulatedFailures = asInt("AXME_SIMULATED_FAILURES", 2);
+  const baseBackoffSeconds = asInt("AXME_BASE_BACKOFF_SECONDS", 1);
+
+  const client = new AxmeClient({ baseUrl, apiKey, actorToken });
+  const correlationId = crypto.randomUUID();
+  const idempotencyKey = `retry-${correlationId}`;
+  const payload = {
+    intent_type: "intent.retry.demo.v1",
+    correlation_id: correlationId,
+    from_agent: fromAgent,
+    to_agent: toAgent,
+    payload: {
+      task: "sync_remote_inventory",
+      target_system: "warehouse-api",
+    },
+  };
+
+  const createdFirst = await client.createIntent(payload, { correlationId, idempotencyKey });
+  const createdSecond = await client.createIntent(payload, { correlationId, idempotencyKey });
+  const intentId = String(createdFirst.intent_id);
+  console.log(`[create] intent_id=${intentId} status=${String(createdFirst.status ?? "unknown")}`);
+  console.log(`[idempotency] replay_intent_id=${String(createdSecond.intent_id ?? "unknown")}`);
+
+  let attempts = 0;
+  const delays: number[] = [];
+  let externalResult: Record<string, unknown> | undefined;
+
+  while (attempts < maxAttempts) {
+    attempts += 1;
+    try {
+      externalResult = runExternalStep(attempts, simulatedFailures);
+      console.log(`[attempt ${attempts}] external step succeeded`);
+      break;
+    } catch (error) {
+      const delaySeconds = baseBackoffSeconds * 2 ** (attempts - 1);
+      delays.push(delaySeconds);
+      console.log(`[attempt ${attempts}] ${(error as Error).message}; backing off for ${delaySeconds}s`);
+      const controls = await client.updateIntentControls(
+        intentId,
+        {
+          controls_patch: {
+            last_retry_attempt: attempts,
+            next_retry_delay_seconds: delaySeconds,
+          },
+          reason: `retry attempt ${attempts} failed`,
+        },
+        { ownerAgent },
+      );
+      console.log(
+        `[controls] applied=${String(controls.applied ?? "unknown")} policy_generation=${String(controls.policy_generation ?? "unknown")}`,
+      );
+      await new Promise((resolve) => setTimeout(resolve, Math.max(0, delaySeconds) * 1000));
+    }
+  }
+
+  if (externalResult) {
+    const resolved = await client.resolveIntent(intentId, {
+      status: "COMPLETED",
+      result: {
+        attempts,
+        retry_backoff_seconds: delays,
+        external_result: externalResult,
+      },
+    });
+    const event = (resolved.event ?? {}) as Record<string, unknown>;
+    console.log(`[resolve] status=${String(event.status ?? "unknown")}`);
+  } else {
+    const failed = await client.resolveIntent(intentId, {
+      status: "FAILED",
+      error: {
+        code: "max_attempts_exceeded",
+        attempts,
+        retry_backoff_seconds: delays,
+      },
+    });
+    const event = (failed.event ?? {}) as Record<string, unknown>;
+    console.log(`[resolve] status=${String(event.status ?? "unknown")}`);
+  }
+
+  const finalIntent = ((await client.getIntent(intentId)).intent ?? {}) as Record<string, unknown>;
+  console.log(
+    `[final] intent_id=${intentId} status=${String(finalIntent.status ?? "unknown")} lifecycle_status=${String(finalIntent.lifecycle_status ?? "unknown")}`,
+  );
+}
+
+main().catch((error) => {
+  console.error("[error]", error);
+  process.exit(1);
+});

--- a/examples/retry-workflow/typescript/package-lock.json
+++ b/examples/retry-workflow/typescript/package-lock.json
@@ -1,0 +1,160 @@
+{
+  "name": "axme-example-retry-workflow-ts",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "axme-example-retry-workflow-ts",
+      "dependencies": {
+        "@axme/axme": "^0.1.1",
+        "dotenv": "^16.4.5"
+      },
+      "devDependencies": {
+        "@types/node": "^25.3.5",
+        "tsx": "^4.20.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@axme/axme": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@axme/axme/-/axme-0.1.1.tgz",
+      "integrity": "sha512-mbUKRWx1n37yyivGaMLS/z7+WF6Pnl//LvCCJCVQCpQ3+yO5yOJ4FafGWjqTb0AKkDmdbD1bytJSameQYfn34Q==",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.3.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.5.tgz",
+      "integrity": "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.6",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/examples/retry-workflow/typescript/package.json
+++ b/examples/retry-workflow/typescript/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "axme-example-retry-workflow-ts",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx main.ts"
+  },
+  "dependencies": {
+    "@axme/axme": "^0.1.1",
+    "dotenv": "^16.4.5"
+  },
+  "devDependencies": {
+    "@types/node": "^25.3.5",
+    "tsx": "^4.20.0"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/examples/retry-workflow/typescript/tsconfig.json
+++ b/examples/retry-workflow/typescript/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "types": [
+      "node"
+    ],
+    "lib": [
+      "ES2022"
+    ],
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "main.ts"
+  ]
+}

--- a/protocol/README.md
+++ b/protocol/README.md
@@ -1,0 +1,17 @@
+# Protocol Examples Index
+
+These examples are **AXP protocol only** and do not require AXME Cloud runtime.
+
+Use this path when you want to:
+
+- implement an AXP-compatible component
+- validate protocol contracts locally
+- run conformance against your own implementation
+
+## Example set
+
+- `create-intent` - minimal protocol payload and submission contract
+- `minimal-axp-service` - minimal lifecycle service (`accept -> complete`)
+- `conformance-runner` - conformance execution flow against custom endpoint
+
+If you want full end-to-end orchestration examples with retries/callbacks/coordination, use Cloud examples in `../cloud/README.md`.

--- a/protocol/conformance-runner/README.md
+++ b/protocol/conformance-runner/README.md
@@ -1,0 +1,23 @@
+# Protocol Example: Conformance Runner
+
+Goal: run AXP conformance tests against your own implementation.
+
+## Prerequisites
+
+- an AXP-compatible endpoint implementation
+- access to `axme-conformance` repository
+
+## Typical flow
+
+1. Start your implementation endpoint (local/staging)
+2. Configure conformance target URL and auth mode
+3. Execute conformance suite
+4. Review pass/fail matrix and fix mismatches
+
+Helper in this folder:
+
+- `run_conformance.sh` - minimal command scaffold for target URL
+
+## Why this matters
+
+Conformance validates that custom implementations stay protocol-compatible even when not using AXME Cloud runtime.

--- a/protocol/conformance-runner/run_conformance.sh
+++ b/protocol/conformance-runner/run_conformance.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${TARGET_BASE_URL:?Set TARGET_BASE_URL for your implementation endpoint}"
+
+echo "Run axme-conformance against: ${TARGET_BASE_URL}"
+echo "Example:"
+echo "  git clone https://github.com/AxmeAI/axme-conformance.git"
+echo "  cd axme-conformance"
+echo "  TARGET_BASE_URL=${TARGET_BASE_URL} make test"

--- a/protocol/create-intent/README.md
+++ b/protocol/create-intent/README.md
@@ -1,0 +1,34 @@
+# Protocol Example: Create Intent
+
+Goal: show the minimal AXP-style intent envelope and protocol-level submission flow.
+
+This example is runtime-agnostic. It does not depend on AXME Cloud orchestration features.
+
+## Minimal payload shape
+
+```json
+{
+  "intent_type": "demo.intent.v1",
+  "correlation_id": "3f1680f7-64bb-4a74-a8b4-bf5bc6a8ad84",
+  "from_agent": "agent://source",
+  "to_agent": "agent://target",
+  "payload": {
+    "task": "demo"
+  }
+}
+```
+
+Files in this folder:
+
+- `intent.json` - baseline payload
+- `send_with_curl.sh` - simple protocol submission helper
+
+## Protocol check goals
+
+- valid required fields
+- stable idempotency key on retries
+- deterministic response contract from receiver
+
+## Next step
+
+Use `../minimal-axp-service` for a tiny service that accepts and resolves intents.

--- a/protocol/create-intent/intent.json
+++ b/protocol/create-intent/intent.json
@@ -1,0 +1,9 @@
+{
+  "intent_type": "demo.intent.v1",
+  "correlation_id": "3f1680f7-64bb-4a74-a8b4-bf5bc6a8ad84",
+  "from_agent": "agent://source",
+  "to_agent": "agent://target",
+  "payload": {
+    "task": "demo"
+  }
+}

--- a/protocol/create-intent/send_with_curl.sh
+++ b/protocol/create-intent/send_with_curl.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${TARGET_URL:?Set TARGET_URL, e.g. http://localhost:8080/v1/intents}"
+
+curl -sS -X POST "${TARGET_URL}" \
+  -H "content-type: application/json" \
+  --data-binary "@intent.json"

--- a/protocol/minimal-axp-service/README.md
+++ b/protocol/minimal-axp-service/README.md
@@ -1,0 +1,25 @@
+# Protocol Example: Minimal AXP Service
+
+Goal: demonstrate a tiny AXP-compatible lifecycle implementation without AXME Cloud runtime.
+
+## Expected flow
+
+1. Receive intent payload (`POST /v1/intents`)
+2. Return accepted state (`CREATED` or `SUBMITTED`)
+3. Expose status endpoint (`GET /v1/intents/{id}`)
+4. Emit terminal state (`COMPLETED` or `FAILED`)
+
+Files in this folder:
+
+- `minimal_service.py` - tiny FastAPI service implementing the lifecycle surface
+- `requirements.txt` - dependencies for local run
+
+## Contract focus
+
+- lifecycle transitions are explicit and observable
+- idempotency key replay returns deterministic response
+- protocol fields remain schema-compatible
+
+## Notes
+
+This is intentionally minimal and does not include managed-runtime features such as durable retries, orchestration policies, or registry routing.

--- a/protocol/minimal-axp-service/minimal_service.py
+++ b/protocol/minimal-axp-service/minimal_service.py
@@ -1,0 +1,20 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+_store: dict[str, dict] = {}
+
+
+@app.post("/v1/intents")
+def create_intent(payload: dict) -> dict:
+    intent_id = payload.get("correlation_id", "intent-demo")
+    _store[intent_id] = {
+        "intent_id": intent_id,
+        "status": "COMPLETED",
+        "result": {"accepted": True},
+    }
+    return {"intent_id": intent_id, "status": "CREATED"}
+
+
+@app.get("/v1/intents/{intent_id}")
+def get_intent(intent_id: str) -> dict:
+    return _store.get(intent_id, {"intent_id": intent_id, "status": "NOT_FOUND"})

--- a/protocol/minimal-axp-service/requirements.txt
+++ b/protocol/minimal-axp-service/requirements.txt
@@ -1,0 +1,2 @@
+fastapi>=0.115
+uvicorn>=0.30

--- a/snippets/README.md
+++ b/snippets/README.md
@@ -1,0 +1,86 @@
+# Additional SDK Snippets
+
+This directory tracks short usage snippets for SDKs that are not maintained as full runnable projects in every scenario.
+
+Current policy:
+
+- Full runnable examples: **Python** and **TypeScript**
+- Snippet-only support: **Go**, **Java**, **.NET**
+- Protocol-only examples (no cloud runtime): `../protocol/`
+
+These snippets are shown for AXME Cloud usage and require an API key generated on the landing page.
+Get API key: <https://cloud.axme.ai/alpha>
+
+Environment model:
+
+- `AXME_API_KEY` - required
+- `AXME_BASE_URL` - optional override
+
+## Auto-Approval Workflow Snippet
+
+### Go
+
+```go
+resp, _ := client.CreateIntent(ctx, axme.CreateIntentRequest{
+    IntentType: "intent.approval.demo.v1",
+    CorrelationID: correlationID,
+    FromAgent: "agent://requester",
+    ToAgent: "agent://approver",
+    Payload: map[string]any{"request_id": "req-123"},
+})
+_ = client.ResumeIntent(ctx, resp.IntentID, axme.ResumeIntentRequest{
+    ApproveCurrentStep: true,
+    Reason: "auto-approved by policy",
+}, axme.WithOwnerAgent("agent://requester"))
+_ = client.ResolveIntent(ctx, resp.IntentID, axme.ResolveIntentRequest{
+    Status: "COMPLETED",
+    Result: map[string]any{"approved": true, "mode": "automatic"},
+})
+```
+
+### Java
+
+```java
+var created = client.createIntent(Map.of(
+    "intent_type", "intent.approval.demo.v1",
+    "correlation_id", correlationId,
+    "from_agent", "agent://requester",
+    "to_agent", "agent://approver",
+    "payload", Map.of("request_id", "req-123")
+), CreateIntentOptions.builder().correlationId(correlationId).build());
+
+client.resumeIntent(created.intentId(), Map.of(
+    "approve_current_step", true,
+    "reason", "auto-approved by policy"
+), ResolveIntentOptions.builder().ownerAgent("agent://requester").build());
+
+client.resolveIntent(created.intentId(), Map.of(
+    "status", "COMPLETED",
+    "result", Map.of("approved", true, "mode", "automatic")
+));
+```
+
+### .NET
+
+```csharp
+var created = await client.CreateIntentAsync(new Dictionary<string, object?>
+{
+    ["intent_type"] = "intent.approval.demo.v1",
+    ["correlation_id"] = correlationId,
+    ["from_agent"] = "agent://requester",
+    ["to_agent"] = "agent://approver",
+    ["payload"] = new Dictionary<string, object?> { ["request_id"] = "req-123" },
+}, new CreateIntentOptions { CorrelationId = correlationId });
+
+await client.ResumeIntentAsync(created.IntentId, new Dictionary<string, object?>
+{
+    ["approve_current_step"] = true,
+    ["reason"] = "auto-approved by policy",
+}, new ResolveIntentOptions { OwnerAgent = "agent://requester" });
+
+await client.ResolveIntentAsync(created.IntentId, new Dictionary<string, object?>
+{
+    ["status"] = "COMPLETED",
+    ["result"] = new Dictionary<string, object?> { ["approved"] = true, ["mode"] = "automatic" },
+});
+```


### PR DESCRIPTION
## Summary
- restructure `axme-examples` into explicit `cloud/` and `protocol/` hubs with clear runtime expectations
- add canonical cloud workflows (Python + TypeScript runnable) and protocol-only starter assets (`create-intent`, `minimal-axp-service`, `conformance-runner`)
- update README, roadmap, snippets, and matrix docs to make `AXME_API_KEY` + optional `AXME_BASE_URL` the consistent cloud entry path

## Test plan
- [x] run all cloud examples (4 Python + 4 TypeScript) against `https://api.cloud.axme.ai`
- [x] run protocol create-intent against local minimal service
- [x] run protocol conformance helper script

Made with [Cursor](https://cursor.com)