### PR TITLE
feat(examples): multi-actor-approval example — requester + approver with distinct actor_tokens

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -2,10 +2,11 @@
 
 Use-case-first canonical **Cloud runtime** examples:
 
-1. `approval-workflow`
-2. `external-callback`
-3. `retry-workflow`
-4. `multi-service-coordination`
+1. `approval-workflow` — single-actor auto-approval path
+2. `external-callback` — waiting for an external callback
+3. `retry-workflow` — automatic retry with backoff
+4. `multi-service-coordination` — parallel child intents
+5. `multi-actor-approval` — two distinct actors (requester + approver), each with their own `actor_token`
 
 Each scenario includes:
 

--- a/examples/multi-actor-approval/.env.example
+++ b/examples/multi-actor-approval/.env.example
@@ -1,0 +1,17 @@
+# Multi-actor approval example environment
+
+# Required: AXME Cloud API key from https://cloud.axme.ai/alpha
+AXME_API_KEY=replace-with-api-key
+
+# Optional override. If omitted, example uses AXME Cloud default endpoint.
+AXME_BASE_URL=https://api.cloud.axme.ai
+
+# Required: actor JWTs for the two actors in the approval flow.
+# Both actors share the same workspace (AXME_API_KEY) but present distinct identity.
+# In a real system, these would be different users/services authenticated to the platform.
+AXME_REQUESTER_TOKEN=replace-with-requester-jwt
+AXME_APPROVER_TOKEN=replace-with-approver-jwt
+
+# Optional: override agent addresses (defaults are usable as-is)
+AXME_REQUESTER_AGENT=agent://examples/requester
+AXME_APPROVER_AGENT=agent://examples/approver

--- a/examples/multi-actor-approval/README.md
+++ b/examples/multi-actor-approval/README.md
@@ -1,0 +1,82 @@
+# Multi-Actor Approval
+
+Problem: an operation requires explicit approval from a different actor (human reviewer, on-call lead, compliance officer) before execution can proceed.  
+Goal: keep one durable intent lifecycle across both actors — requester and approver — without shared mutable state.
+
+This example demonstrates:
+
+- creating an intent that enters **WAITING** state (requires external input to proceed)
+- a **second actor** using their own `actor_token` to resume the intent
+- durable result recording — the approval decision is part of the lifecycle
+- reading the final outcome as the original requester
+
+## The `actor_token` Pattern
+
+Both actors share the same `AXME_API_KEY` (workspace credential) but carry different identity tokens (`actor_token`). This is the AXP multi-actor pattern:
+
+- **API key** = workspace access gate (which workspace you're talking to)
+- **actor_token** = actor identity (who is acting within the workspace)
+
+The durable intent lifecycle captures each actor's actions separately in the event chain — providing a full audit trail with no external coordination needed.
+
+## Requirements
+
+This example runs against **AXME Cloud**.
+
+You need:
+
+- AXME Cloud API key (generated on the landing page)
+- Two JWT `actor_token` values (one per actor)
+- `.env` file with `AXME_API_KEY`, `AXME_REQUESTER_TOKEN`, and `AXME_APPROVER_TOKEN` set
+
+Get API key at:
+
+- <https://cloud.axme.ai/alpha>
+
+```mermaid
+sequenceDiagram
+    participant R as Requester (actor_token: requester)
+    participant AXME as AXME Cloud Runtime
+    participant A as Approver (actor_token: approver)
+
+    R->>AXME: POST /v1/intents (approval request)
+    AXME-->>R: intent_id, status=WAITING
+    Note over AXME: Intent pauses — waits for approval
+    A->>AXME: GET /v1/intents/{id} (review)
+    A->>AXME: POST /v1/intents/{id}/resume (approve)
+    A->>AXME: POST /v1/intents/{id}/resolve (COMPLETED)
+    R->>AXME: GET /v1/intents/{id} (read result)
+    AXME-->>R: result.approval_result=approved
+```
+
+## Run (Python)
+
+```bash
+cd examples/multi-actor-approval/python
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+cp ../.env.example ../.env
+# edit ../.env and set AXME_API_KEY, AXME_REQUESTER_TOKEN, AXME_APPROVER_TOKEN
+python main.py
+```
+
+## Key Concepts
+
+### Why two tokens for one workspace?
+
+A single workspace represents a shared execution environment (e.g. your org's production namespace). Within it, different principals — humans, services, automated systems — can act. Each gets their own `actor_token` scoped to their identity. The workspace API key controls *access*; the actor token controls *identity*.
+
+### The WAITING state
+
+An intent enters `WAITING` when the runtime recognizes it cannot proceed autonomously. The intent lifecycle is preserved durably. Any authorized actor can call `resume` to unblock it — no polling loop or message queue needed.
+
+### Audit trail
+
+After running this example, call `GET /v1/intents/{id}/events` to see the full event chain. Both the requester's create action and the approver's resume/resolve actions appear with distinct actor identities.
+
+## See Also
+
+- [Approval Workflow](../approval-workflow/) — single-actor auto-approval flow
+- [Multi-Service Coordination](../multi-service-coordination/) — parallel child intents
+- [axme-sdk-python](https://github.com/AxmeAI/axme-sdk-python) — Python SDK reference

--- a/examples/multi-actor-approval/python/main.py
+++ b/examples/multi-actor-approval/python/main.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+"""Multi-actor approval: Requester and Approver use distinct actor_tokens.
+
+This example demonstrates the core AXP pattern for human-in-the-loop approvals
+where two different actors (requester and approver) each present their own
+actor_token to the same AXME Cloud workspace.
+
+Flow:
+  1. Requester creates an approval intent (enters WAITING state after creation).
+  2. Runtime puts the intent in WAITING — execution pauses until unblocked.
+  3. Approver (different actor) resumes the intent with their actor_token.
+  4. Requester polls for the terminal state and reads the approval result.
+
+Why this matters (vs. single-actor flow):
+  - The durable lifecycle is preserved across both actors — no polling for
+    hand-off, no shared mutable state outside the intent.
+  - Each actor's token creates an auditable action chain in the lifecycle events.
+  - The approval decision is recorded durably and can be inspected after the fact.
+
+Usage:
+    export AXME_API_KEY="axme_sa_..."
+    export AXME_REQUESTER_TOKEN="eyJ..."   # JWT for the requesting actor
+    export AXME_APPROVER_TOKEN="eyJ..."    # JWT for the approving actor
+    python main.py
+"""
+
+import os
+import time
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from dotenv import load_dotenv
+
+from axme import AxmeClient, AxmeClientConfig
+
+
+def _require_env(name: str) -> str:
+    value = os.getenv(name, "").strip()
+    if not value:
+        raise RuntimeError(f"missing required env var: {name}")
+    return value
+
+
+def _print_events(label: str, events: list[dict[str, Any]]) -> None:
+    print(f"\n[{label}] lifecycle events:")
+    for event in events:
+        seq = event.get("seq", 0)
+        status = event.get("status", "unknown")
+        actor = event.get("actor_id") or event.get("actor") or "system"
+        waiting_reason = event.get("waiting_reason")
+        suffix = f" waiting_reason={waiting_reason}" if waiting_reason else ""
+        print(f"  seq={seq}  status={status}  actor={actor}{suffix}")
+
+
+def main() -> None:
+    load_dotenv(Path(__file__).resolve().parent.parent / ".env")
+
+    base_url = os.getenv("AXME_BASE_URL", "https://api.cloud.axme.ai").strip()
+    api_key = _require_env("AXME_API_KEY")
+    requester_token = _require_env("AXME_REQUESTER_TOKEN")
+    approver_token = _require_env("AXME_APPROVER_TOKEN")
+
+    requester_agent = os.getenv("AXME_REQUESTER_AGENT", "agent://examples/requester").strip()
+    approver_agent = os.getenv("AXME_APPROVER_AGENT", "agent://examples/approver").strip()
+
+    # --- Step 1: Requester creates the approval intent ---
+    print("\n=== Step 1: Requester creates approval intent ===")
+    requester_config = AxmeClientConfig(
+        base_url=base_url,
+        api_key=api_key,
+        actor_token=requester_token,
+    )
+    correlation_id = str(uuid4())
+    idempotency_key = f"multi-actor-approval-{correlation_id}"
+
+    with AxmeClient(requester_config) as requester:
+        created = requester.create_intent(
+            {
+                "intent_type": "intent.approval.multi_actor.v1",
+                "correlation_id": correlation_id,
+                "from_agent": requester_agent,
+                "to_agent": approver_agent,
+                "payload": {
+                    "request_id": f"req-{correlation_id[:8]}",
+                    "summary": "Deploy backend service v2.4.1 to production",
+                    "requested_by": requester_agent,
+                    "approval_mode": "manual",
+                    "risk_level": "high",
+                },
+            },
+            correlation_id=correlation_id,
+            idempotency_key=idempotency_key,
+        )
+        intent_id = str(created["intent_id"])
+        initial_status = created.get("status")
+        print(f"[requester] intent_id={intent_id} status={initial_status}")
+        print(f"[requester] correlation_id={correlation_id}")
+
+        # The intent is now in WAITING — the requester's work is done for now.
+        # In a real system, the requester would store the intent_id and come back
+        # to check the result (or receive a callback/webhook).
+        print("\n[requester] Intent is in WAITING state. Handing off to approver.")
+
+    # --- Step 2: Approver reviews and resumes the intent ---
+    # This simulates the approver opening their approval queue, seeing the intent,
+    # and making a decision. They use their own actor_token.
+    print("\n=== Step 2: Approver reviews and approves ===")
+
+    # Small pause to simulate the approver being a different system/user.
+    time.sleep(0.5)
+
+    approver_config = AxmeClientConfig(
+        base_url=base_url,
+        api_key=api_key,
+        actor_token=approver_token,
+    )
+
+    with AxmeClient(approver_config) as approver:
+        # Approver can inspect the intent before deciding.
+        intent_detail = approver.get_intent(intent_id).get("intent", {})
+        print(f"[approver] reviewing intent_id={intent_id}")
+        print(f"[approver] current status={intent_detail.get('status')}")
+        payload_data = intent_detail.get("payload") or {}
+        summary = payload_data.get("summary") or "(no summary)"
+        risk_level = payload_data.get("risk_level") or "unknown"
+        print(f"[approver] summary: {summary}")
+        print(f"[approver] risk_level: {risk_level}")
+
+        # Approver makes their decision via resume.
+        resumed = approver.resume_intent(
+            intent_id,
+            {
+                "approve_current_step": True,
+                "reason": "Reviewed deployment plan — approved for production.",
+                "approved_by": approver_agent,
+                "approval_timestamp": correlation_id,
+            },
+            owner_agent=approver_agent,
+        )
+        print(
+            f"[approver] resume applied={resumed.get('applied')} "
+            f"policy_generation={resumed.get('policy_generation')}"
+        )
+
+        # Approver resolves the intent to COMPLETED with the approval result.
+        resolved = approver.resolve_intent(
+            intent_id,
+            {
+                "status": "COMPLETED",
+                "result": {
+                    "approval_result": "approved",
+                    "approved_by": approver_agent,
+                    "summary": summary,
+                    "notes": "Production deployment approved by on-call lead.",
+                },
+            },
+        )
+        terminal_event = resolved.get("event", {})
+        print(
+            f"[approver] resolve status={terminal_event.get('status')} "
+            f"type={terminal_event.get('event_type')}"
+        )
+
+    # --- Step 3: Requester reads the final result ---
+    print("\n=== Step 3: Requester reads approval result ===")
+
+    with AxmeClient(requester_config) as requester:
+        final_intent = requester.get_intent(intent_id).get("intent", {})
+        result = final_intent.get("result") or {}
+        print(f"[requester] intent_id={intent_id}")
+        print(f"[requester] final status={final_intent.get('status')}")
+        print(f"[requester] approval_result={result.get('approval_result')}")
+        print(f"[requester] approved_by={result.get('approved_by')}")
+        print(f"[requester] notes={result.get('notes')}")
+
+        # Read lifecycle events — both actors appear in the event chain.
+        listed = requester.list_intent_events(intent_id)
+        events = listed.get("events", [])
+        if isinstance(events, list):
+            _print_events("lifecycle", [e for e in events if isinstance(e, dict)])
+
+    print("\n=== Done ===")
+    print(
+        "The full lifecycle is recorded durably. Each actor's action is "
+        "traceable via the event chain — no shared mutable state outside "
+        "the intent was needed."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/multi-actor-approval/python/requirements.txt
+++ b/examples/multi-actor-approval/python/requirements.txt
@@ -1,0 +1,2 @@
+axme>=0.1.1
+python-dotenv>=1.0.1

--- a/examples/multi-actor-approval/typescript/main.ts
+++ b/examples/multi-actor-approval/typescript/main.ts
@@ -1,0 +1,165 @@
+/**
+ * Multi-actor approval: Requester and Approver use distinct actorTokens.
+ *
+ * This example demonstrates the core AXP pattern for human-in-the-loop approvals
+ * where two different actors (requester and approver) each present their own
+ * actorToken to the same AXME Cloud workspace.
+ *
+ * Flow:
+ *   1. Requester creates an approval intent (enters WAITING state after creation).
+ *   2. Runtime puts the intent in WAITING — execution pauses until unblocked.
+ *   3. Approver (different actor) resumes the intent with their actorToken.
+ *   4. Requester polls for the terminal state and reads the approval result.
+ */
+
+import { config as loadEnv } from "dotenv";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { AxmeClient } from "@axme/axme/dist/src/index.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+loadEnv({ path: path.resolve(__dirname, "..", ".env") });
+
+function requireEnv(name: string): string {
+  const value = (process.env[name] ?? "").trim();
+  if (!value) {
+    throw new Error(`missing required env var: ${name}`);
+  }
+  return value;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function main(): Promise<void> {
+  const baseUrl = (process.env.AXME_BASE_URL ?? "https://api.cloud.axme.ai").trim();
+  const apiKey = requireEnv("AXME_API_KEY");
+  const requesterToken = requireEnv("AXME_REQUESTER_TOKEN");
+  const approverToken = requireEnv("AXME_APPROVER_TOKEN");
+
+  const requesterAgent = (process.env.AXME_REQUESTER_AGENT ?? "agent://examples/requester").trim();
+  const approverAgent = (process.env.AXME_APPROVER_AGENT ?? "agent://examples/approver").trim();
+
+  // --- Step 1: Requester creates the approval intent ---
+  console.log("\n=== Step 1: Requester creates approval intent ===");
+
+  const requester = new AxmeClient({ baseUrl, apiKey, actorToken: requesterToken });
+  const correlationId = crypto.randomUUID();
+  const idempotencyKey = `multi-actor-approval-${correlationId}`;
+
+  const created = await requester.createIntent(
+    {
+      intent_type: "intent.approval.multi_actor.v1",
+      correlation_id: correlationId,
+      from_agent: requesterAgent,
+      to_agent: approverAgent,
+      payload: {
+        request_id: `req-${correlationId.slice(0, 8)}`,
+        summary: "Deploy backend service v2.4.1 to production",
+        requested_by: requesterAgent,
+        approval_mode: "manual",
+        risk_level: "high",
+      },
+    },
+    { correlationId, idempotencyKey },
+  );
+
+  const intentId = String(created.intent_id);
+  console.log(`[requester] intent_id=${intentId} status=${String(created.status ?? "unknown")}`);
+  console.log(`[requester] correlation_id=${correlationId}`);
+  console.log("\n[requester] Intent is in WAITING state. Handing off to approver.");
+
+  // --- Step 2: Approver reviews and approves ---
+  console.log("\n=== Step 2: Approver reviews and approves ===");
+
+  // Small pause to simulate the approver being a different system/user.
+  await sleep(500);
+
+  const approver = new AxmeClient({ baseUrl, apiKey, actorToken: approverToken });
+
+  // Approver can inspect the intent before deciding.
+  const intentDetail = await approver.getIntent(intentId);
+  const intentData = (intentDetail.intent ?? {}) as Record<string, unknown>;
+  console.log(`[approver] reviewing intent_id=${intentId}`);
+  console.log(`[approver] current status=${String(intentData.status ?? "unknown")}`);
+
+  const payloadData = (intentData.payload ?? {}) as Record<string, unknown>;
+  const summary = String(payloadData.summary ?? "(no summary)");
+  const riskLevel = String(payloadData.risk_level ?? "unknown");
+  console.log(`[approver] summary: ${summary}`);
+  console.log(`[approver] risk_level: ${riskLevel}`);
+
+  // Approver makes their decision via resume.
+  const resumed = await approver.resumeIntent(
+    intentId,
+    {
+      approve_current_step: true,
+      reason: "Reviewed deployment plan — approved for production.",
+      approved_by: approverAgent,
+    },
+    { ownerAgent: approverAgent },
+  );
+  console.log(
+    `[approver] resume applied=${String(resumed.applied ?? "unknown")} ` +
+      `policy_generation=${String(resumed.policy_generation ?? "unknown")}`,
+  );
+
+  // Approver resolves the intent to COMPLETED with the approval result.
+  const resolved = await approver.resolveIntent(intentId, {
+    status: "COMPLETED",
+    result: {
+      approval_result: "approved",
+      approved_by: approverAgent,
+      summary,
+      notes: "Production deployment approved by on-call lead.",
+    },
+  });
+  const terminalEvent = (resolved.event ?? {}) as Record<string, unknown>;
+  console.log(
+    `[approver] resolve status=${String(terminalEvent.status ?? "unknown")} ` +
+      `type=${String(terminalEvent.event_type ?? "unknown")}`,
+  );
+
+  // --- Step 3: Requester reads the final result ---
+  console.log("\n=== Step 3: Requester reads approval result ===");
+
+  const finalIntent = await requester.getIntent(intentId);
+  const finalData = (finalIntent.intent ?? {}) as Record<string, unknown>;
+  const result = (finalData.result ?? {}) as Record<string, unknown>;
+  console.log(`[requester] intent_id=${intentId}`);
+  console.log(`[requester] final status=${String(finalData.status ?? "unknown")}`);
+  console.log(`[requester] approval_result=${String(result.approval_result ?? "unknown")}`);
+  console.log(`[requester] approved_by=${String(result.approved_by ?? "unknown")}`);
+  console.log(`[requester] notes=${String(result.notes ?? "")}`);
+
+  // Read lifecycle events — both actors appear in the event chain.
+  const listed = await requester.listIntentEvents(intentId);
+  const events = (listed.events ?? []) as Array<Record<string, unknown>>;
+  if (events.length > 0) {
+    console.log("\n[lifecycle] events:");
+    for (const event of events) {
+      const seq = event.seq ?? 0;
+      const evStatus = event.status ?? "unknown";
+      const actor = event.actor_id ?? event.actor ?? "system";
+      const waitingReason = event.waiting_reason;
+      const suffix = waitingReason ? ` waiting_reason=${String(waitingReason)}` : "";
+      console.log(`  seq=${String(seq)}  status=${String(evStatus)}  actor=${String(actor)}${suffix}`);
+    }
+  }
+
+  console.log("\n=== Done ===");
+  console.log(
+    "The full lifecycle is recorded durably. Each actor's action is " +
+      "traceable via the event chain — no shared mutable state outside " +
+      "the intent was needed.",
+  );
+}
+
+main().catch((err: unknown) => {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+});

--- a/examples/multi-actor-approval/typescript/package.json
+++ b/examples/multi-actor-approval/typescript/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "axme-example-multi-actor-approval-ts",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx main.ts"
+  },
+  "dependencies": {
+    "@axme/axme": "^0.1.1",
+    "dotenv": "^16.4.5"
+  },
+  "devDependencies": {
+    "@types/node": "^25.3.5",
+    "tsx": "^4.20.0"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/examples/multi-actor-approval/typescript/tsconfig.json
+++ b/examples/multi-actor-approval/typescript/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "types": [
+      "node"
+    ],
+    "lib": [
+      "ES2022"
+    ],
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "main.ts"
+  ]
+}


### PR DESCRIPTION
## Summary

Adds `examples/multi-actor-approval/` — a new canonical example demonstrating the AXP multi-actor pattern.

**The problem it solves**: a high-risk operation (e.g. production deployment) requires explicit approval from a second human/system before execution proceeds. Both principals share the same workspace but carry distinct actor tokens.

**Flow:**
1. Requester creates an intent → enters WAITING state
2. Approver (different `actorToken`) inspects, resumes with decision, and resolves to COMPLETED
3. Requester reads the durable approval result

**What's included:**
- `python/main.py` — full step-by-step implementation with print tracing
- `typescript/main.ts` — equivalent TypeScript implementation
- `.env.example` — with `AXME_REQUESTER_TOKEN` and `AXME_APPROVER_TOKEN`
- `README.md` — Mermaid sequence diagram, key concepts (WAITING state, two-token model), run instructions, cross-links

**Updated `examples/README.md`** to add the new entry (#5) with description.

## Test plan
- [x] Python code is syntactically correct (imports, type annotations, error handling)
- [x] TypeScript code uses correct SDK method names (`createIntent`, `getIntent`, `resumeIntent`, `resolveIntent`, `listIntentEvents`)
- [x] `actor_token`/`actorToken` usage follows the two-token model from the AXME auth spec
- [x] README Mermaid diagram renders correctly
- [x] CI passes (structure check)

Implements H.4 of Wave 4 execution plan.

Made with [Cursor](https://cursor.com)