### PR TITLE
fix: helpful error when AXME_API_KEY is not set

### DIFF
--- a/examples/approval-workflow/python/main.py
+++ b/examples/approval-workflow/python/main.py
@@ -13,7 +13,10 @@ from axme import AxmeClient, AxmeClientConfig
 def _require_env(name: str) -> str:
     value = os.getenv(name, "").strip()
     if not value:
-        raise RuntimeError(f"missing required env var: {name}")
+        raise RuntimeError(
+            f"{name} is not set. Run 'axme login' to sign in, then:\n"
+            f"  export {name}=$(axme context show --show-key --json | jq -r .api_key)"
+        )
     return value
 
 

--- a/examples/approval-workflow/typescript/main.ts
+++ b/examples/approval-workflow/typescript/main.ts
@@ -11,7 +11,10 @@ loadEnv({ path: path.resolve(__dirname, "..", ".env") });
 function requireEnv(name: string): string {
   const value = (process.env[name] ?? "").trim();
   if (!value) {
-    throw new Error(`missing required env var: ${name}`);
+    throw new Error(
+      `${name} is not set. Run 'axme login' to sign in, then:\n` +
+      `  export ${name}=$(axme context show --show-key --json | jq -r .api_key)`
+    );
   }
   return value;
 }


### PR DESCRIPTION
## Summary
- `_require_env` (Python) and `requireEnv` (TypeScript) now show a clear actionable message when `AXME_API_KEY` is missing instead of the generic "missing required env var"
- Example output: `AXME_API_KEY is not set. Run 'axme login' to sign in, then: export AXME_API_KEY=$(axme context show --show-key --json | jq -r .api_key)`

## Test plan
- [x] Verified both files updated correctly

Made with [Cursor](https://cursor.com)