### PR TITLE
fix(stream-agent): unwrap get_intent response and read parent_payload (Bugs #12 #13)

### DIFF
--- a/examples/delivery/stream/agent.py
+++ b/examples/delivery/stream/agent.py
@@ -112,7 +112,8 @@ def handle_intent(client: AxmeClient, delivery: dict[str, Any], *, seq: int = 0)
     log.info("received intent %s", intent_id)
 
     try:
-        intent = client.get_intent(intent_id)
+        resp = client.get_intent(intent_id)
+        intent = resp.get("intent") or resp  # unwrap {"ok": true, "intent": {...}}
     except Exception as exc:
         log.error("get_intent(%s) failed: %s", intent_id, exc)
         return
@@ -125,8 +126,11 @@ def handle_intent(client: AxmeClient, delivery: dict[str, Any], *, seq: int = 0)
         log.debug("skipping intent %s with status %s", intent_id, status)
         return
 
-    payload = intent.get("payload") or {}
-    passed, reason = _check_compliance(payload)
+    raw_payload = intent.get("payload") or {}
+    # For step-intents: compliance data is in parent_payload.
+    # For direct intents: data is at top level.
+    effective_payload = raw_payload.get("parent_payload") or raw_payload
+    passed, reason = _check_compliance(effective_payload)
 
     log.info("compliance result for %s: passed=%s  reason=%s", intent_id, passed, reason)
 


### PR DESCRIPTION
## Summary
- **Bug #12**: `client.get_intent()` returns `{"ok": true, "intent": {...}}` — agent was reading `lifecycle_status` from the top-level wrapper dict (always `None`) → every intent silently skipped. Now unwraps correctly: `intent = resp.get("intent") or resp`
- **Bug #13 (agent side)**: step-intents carry original business data under `payload.parent_payload`. Agent now reads `effective_payload = raw_payload.get("parent_payload") or raw_payload` so compliance checks have `environment`, `risk_level`, `backup_confirmed`

## Test plan
- [x] Syntax check passes
- [ ] E2E: apply delivery/stream scenario → agent processes step-intent → compliance check passes → parent intent COMPLETED

🤖 Generated with [Claude Code](https://claude.com/claude-code)