### PR TITLE
fix(stream-agent): log full resume_intent response for diagnostics

### DIFF
--- a/examples/delivery/stream/agent.py
+++ b/examples/delivery/stream/agent.py
@@ -136,7 +136,7 @@ def handle_intent(client: AxmeClient, delivery: dict[str, Any], *, seq: int = 0)
 
     try:
         if passed:
-            client.resume_intent(
+            resp = client.resume_intent(
                 intent_id,
                 {
                     "action":  "complete",
@@ -147,7 +147,7 @@ def handle_intent(client: AxmeClient, delivery: dict[str, Any], *, seq: int = 0)
                 owner_agent=AXME_AGENT_ADDRESS,
             )
         else:
-            client.resume_intent(
+            resp = client.resume_intent(
                 intent_id,
                 {
                     "action": "fail",
@@ -156,7 +156,7 @@ def handle_intent(client: AxmeClient, delivery: dict[str, Any], *, seq: int = 0)
                 },
                 owner_agent=AXME_AGENT_ADDRESS,
             )
-        log.info("resumed intent %s  (passed=%s)", intent_id, passed)
+        log.info("resumed intent %s  (passed=%s)  response=%s", intent_id, passed, resp)
         # Advance the delivery cursor so the next startup skips this intent.
         if seq > 0:
             _save_since(seq)


### PR DESCRIPTION
## Summary
- Captures and logs full response from `client.resume_intent()` including `applied` field
- Helps diagnose Bug #14 (intent not transitioning to COMPLETED): if Gateway returns `applied=false`, it's immediately visible in agent.py output

## Test plan
- [ ] Run agent.py and verify log line shows `response={...}` after resume_intent
- [ ] Check `applied` field in response to confirm Gateway accepted the resume

🤖 Generated with [Claude Code](https://claude.com/claude-code)