### PR TITLE
feat(delivery/http): callback_url in scenario + Dockerfile

### DIFF
--- a/examples/delivery/http/Dockerfile
+++ b/examples/delivery/http/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.13-slim
+WORKDIR /app
+RUN pip install --no-cache-dir "axme>=0.1.1"
+COPY agent.py ./agent.py
+ENV PORT=8080
+CMD ["python", "agent.py"]

--- a/examples/delivery/http/scenario.json
+++ b/examples/delivery/http/scenario.json
@@ -9,6 +9,7 @@
       "address": "http-order-processor",
       "display_name": "HTTP Order Processor",
       "delivery_mode": "http",
+      "callback_url": "https://axme-http-agent-1047255398033.us-central1.run.app/intent",
       "create_if_missing": true
     }
   ],


### PR DESCRIPTION
## Summary
- `scenario.json`: add `callback_url` field pointing to deployed Cloud Run agent
- `Dockerfile`: enables deploying the http agent to Cloud Run (python:3.13-slim)

The http agent is deployed at `https://axme-http-agent-1047255398033.us-central1.run.app`. Running `axme scenarios apply examples/delivery/http/scenario.json --watch` now reaches COMPLETED end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)