### PR TITLE
feat(internal): internal runtime examples + fix human tool_id

### DIFF
--- a/examples/human/cli/scenario.json
+++ b/examples/human/cli/scenario.json
@@ -30,7 +30,7 @@
       },
       {
         "step_id": "ops_approval",
-        "tool_id": "tool.human.approval.v1",
+        "tool_id": "tool.approval.human_signoff",
         "assigned_to": "operator",
         "requires_approval": true,
         "step_deadline_seconds": 3600,

--- a/examples/human/email/scenario.json
+++ b/examples/human/email/scenario.json
@@ -30,7 +30,7 @@
       },
       {
         "step_id": "finance_approval",
-        "tool_id": "tool.human.approval.v1",
+        "tool_id": "tool.approval.human_signoff",
         "assigned_to": "approver",
         "requires_approval": true,
         "step_deadline_seconds": 86400,

--- a/examples/human/form/scenario.json
+++ b/examples/human/form/scenario.json
@@ -30,7 +30,7 @@
       },
       {
         "step_id": "security_signoff",
-        "tool_id": "tool.human.approval.v1",
+        "tool_id": "tool.approval.human_signoff",
         "assigned_to": "security_officer",
         "requires_approval": true,
         "step_deadline_seconds": 7200,

--- a/examples/internal/delay/agent.py
+++ b/examples/internal/delay/agent.py
@@ -1,0 +1,182 @@
+"""Change Window Validator — internal/delay example.
+
+Delivery: stream  (GET /v1/agents/{address}/intents/stream)
+
+Validates that a change falls within an approved maintenance window.
+Demonstrates a real async validation pattern: the agent checks the
+window schedule and validates all required fields before responding.
+The step has a 120-second deadline (`step_deadline_seconds: 120`).
+
+Run (Terminal 1 — agent):
+    export AXME_API_KEY=<your-api-key>
+    export AXME_AGENT_ADDRESS=agent://<org>/<workspace>/change-window-validator
+    python agent.py
+
+Run (Terminal 2 — scenario):
+    axme scenarios apply examples/internal/delay/scenario.json --watch
+
+To observe step deadline: stop the agent before it responds.
+AXME will transition the step to TIMED_OUT after 120 seconds.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+from typing import Any
+
+from axme import AxmeClient, AxmeClientConfig
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s  [%(levelname)s]  %(message)s",
+    datefmt="%H:%M:%S",
+)
+log = logging.getLogger("change-window-validator")
+
+AXME_BASE_URL      = os.environ.get("AXME_BASE_URL", "https://api.cloud.axme.ai")
+AXME_API_KEY       = os.environ.get("AXME_API_KEY", "")
+AXME_AGENT_ADDRESS = os.environ.get("AXME_AGENT_ADDRESS", "change-window-validator")
+
+if not AXME_API_KEY:
+    sys.exit("AXME_API_KEY is required")
+
+# ---------------------------------------------------------------------------
+# Change window validation rules
+# ---------------------------------------------------------------------------
+# Approved maintenance windows: weekday evenings and weekends.
+# Changes outside these windows are rejected.
+
+_APPROVED_WINDOW_IDS = {
+    "MW-2026-Q1-01", "MW-2026-Q1-02", "MW-2026-Q1-03",
+    "MW-2026-Q1-04", "MW-2026-Q1-05", "MW-2026-Q1-06",
+}
+
+_ALLOWED_CHANGE_TYPES = {"config_update", "dependency_update", "rollback", "hotfix"}
+
+_BLOCKED_ENVIRONMENTS_WITHOUT_WINDOW = {"production"}
+
+
+def _validate_change_window(payload: dict[str, Any]) -> tuple[bool, str, dict[str, Any]]:
+    """Return (allowed, reason, metadata)."""
+    change_id    = payload.get("change_id", "?")
+    environment  = payload.get("environment", "")
+    change_type  = payload.get("change_type", "")
+    window_id    = payload.get("window_id", "")
+    scheduled_at = payload.get("scheduled_at", "")
+
+    # Check 1 — change type allowed
+    if change_type not in _ALLOWED_CHANGE_TYPES:
+        return (
+            False,
+            f"{change_id}: change_type {change_type!r} is not in allowed set {sorted(_ALLOWED_CHANGE_TYPES)}",
+            {},
+        )
+
+    # Check 2 — production changes must have an approved window
+    if environment in _BLOCKED_ENVIRONMENTS_WITHOUT_WINDOW:
+        if not window_id:
+            return (
+                False,
+                f"{change_id}: production changes require an approved window_id",
+                {},
+            )
+        if window_id not in _APPROVED_WINDOW_IDS:
+            return (
+                False,
+                f"{change_id}: window_id {window_id!r} is not in the approved window list",
+                {},
+            )
+
+    # Check 3 — scheduled_at is a valid ISO timestamp
+    if scheduled_at:
+        try:
+            datetime.fromisoformat(scheduled_at.replace("Z", "+00:00"))
+        except ValueError:
+            return (
+                False,
+                f"{change_id}: scheduled_at {scheduled_at!r} is not a valid ISO timestamp",
+                {},
+            )
+
+    window_info = {}
+    if window_id and window_id in _APPROVED_WINDOW_IDS:
+        window_info = {"window_id": window_id, "window_approved": True}
+
+    return (
+        True,
+        f"{change_id}: change window validated for {environment!r} environment",
+        window_info,
+    )
+
+
+def handle_intent(client: AxmeClient, delivery: dict[str, Any]) -> None:
+    intent_id = delivery.get("intent_id", "")
+    if not intent_id:
+        log.warning("received delivery without intent_id, skipping")
+        return
+
+    log.info("received intent %s", intent_id)
+
+    try:
+        resp   = client.get_intent(intent_id)
+        intent = resp.get("intent") or resp
+    except Exception as exc:
+        log.error("get_intent(%s) failed: %s", intent_id, exc)
+        return
+
+    status = (intent.get("lifecycle_status") or intent.get("status") or "").upper()
+    if status not in {"CREATED", "DELIVERED", "ACKNOWLEDGED", "IN_PROGRESS", "WAITING"}:
+        log.debug("skipping intent %s with status %s", intent_id, status)
+        return
+
+    raw_payload       = intent.get("payload") or {}
+    effective_payload = raw_payload.get("parent_payload") or raw_payload
+
+    allowed, reason, meta = _validate_change_window(effective_payload)
+    log.info("window validation for %s: allowed=%s  reason=%s", intent_id, allowed, reason)
+
+    try:
+        if allowed:
+            client.resume_intent(
+                intent_id,
+                {
+                    "action":  "complete",
+                    "allowed": True,
+                    "reason":  reason,
+                    **meta,
+                },
+                owner_agent=AXME_AGENT_ADDRESS,
+            )
+        else:
+            client.resume_intent(
+                intent_id,
+                {
+                    "action":  "fail",
+                    "allowed": False,
+                    "reason":  reason,
+                },
+                owner_agent=AXME_AGENT_ADDRESS,
+            )
+        log.info("resumed intent %s (allowed=%s)", intent_id, allowed)
+    except Exception as exc:
+        log.error("resume_intent(%s) failed: %s", intent_id, exc)
+
+
+def main() -> None:
+    client = AxmeClient(AxmeClientConfig(api_key=AXME_API_KEY, base_url=AXME_BASE_URL))
+    log.info(
+        "change-window-validator starting  address=%s  binding=stream",
+        AXME_AGENT_ADDRESS,
+    )
+
+    try:
+        for delivery in client.listen(AXME_AGENT_ADDRESS, timeout_seconds=None):
+            handle_intent(client, delivery)
+    except KeyboardInterrupt:
+        log.info("shutting down")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/internal/delay/scenario.json
+++ b/examples/internal/delay/scenario.json
@@ -1,0 +1,39 @@
+{
+  "scenario_id": "internal.delay.v1",
+  "title": "Internal delay — async processing with step deadline",
+  "description": "Demonstrates AXME's step-level deadline mechanism. The change validator agent performs async validation that may take time. The step has a `step_deadline_seconds` deadline — if the agent does not respond in time, the step transitions to TIMED_OUT. This shows how AXME tracks and enforces per-step SLAs.",
+
+  "agents": [
+    {
+      "role": "validator",
+      "address": "change-window-validator",
+      "display_name": "Change Window Validator",
+      "delivery_mode": "stream",
+      "create_if_missing": true
+    }
+  ],
+
+  "workflow": {
+    "steps": [
+      {
+        "step_id": "validate_change_window",
+        "tool_id": "tool.agent.task.v1",
+        "assigned_to": "validator",
+        "step_deadline_seconds": 120
+      }
+    ]
+  },
+
+  "intent": {
+    "type": "intent.change.window_check.v1",
+    "payload": {
+      "change_id":    "CHG-20260314-003",
+      "service":      "payments-processor",
+      "environment":  "staging",
+      "change_type":  "config_update",
+      "scheduled_at": "2026-03-14T18:00:00Z",
+      "window_id":    "MW-2026-Q1-03"
+    },
+    "max_delivery_attempts": 3
+  }
+}

--- a/examples/internal/escalation/agent.py
+++ b/examples/internal/escalation/agent.py
@@ -1,0 +1,150 @@
+"""Incident Classifier Agent — internal/escalation example.
+
+Delivery: stream  (GET /v1/agents/{address}/intents/stream)
+
+Classifies an incident by severity level and affected components.
+After classification, the workflow routes to the on-call engineer with
+a short SLA. If the engineer doesn't acknowledge within the SLA window,
+AXME sends reminder emails. After max_reminders, the step times out
+and AXME escalates the incident automatically.
+
+Run (Terminal 1 — agent):
+    export AXME_API_KEY=<your-api-key>
+    export AXME_AGENT_ADDRESS=agent://<org>/<workspace>/incident-classifier-agent
+    python agent.py
+
+Run (Terminal 2 — scenario):
+    axme scenarios apply examples/internal/escalation/scenario.json --watch
+
+To see escalation: do NOT run `axme tasks approve` — wait for reminders.
+To acknowledge: axme tasks list → axme tasks approve <task_id>
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from typing import Any
+
+from axme import AxmeClient, AxmeClientConfig
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s  [%(levelname)s]  %(message)s",
+    datefmt="%H:%M:%S",
+)
+log = logging.getLogger("incident-classifier")
+
+AXME_BASE_URL      = os.environ.get("AXME_BASE_URL", "https://api.cloud.axme.ai")
+AXME_API_KEY       = os.environ.get("AXME_API_KEY", "")
+AXME_AGENT_ADDRESS = os.environ.get("AXME_AGENT_ADDRESS", "incident-classifier-agent")
+
+if not AXME_API_KEY:
+    sys.exit("AXME_API_KEY is required")
+
+# ---------------------------------------------------------------------------
+# Incident classification rules
+# ---------------------------------------------------------------------------
+_SEVERITY_RESPONSE_SLA: dict[str, int] = {
+    "P1": 5,    # 5 minutes
+    "P2": 15,   # 15 minutes
+    "P3": 60,   # 60 minutes
+    "P4": 240,  # 4 hours
+}
+
+_CRITICAL_SERVICES = {"api-gateway", "auth-service", "payments-processor"}
+
+_HIGH_ERROR_RATE_THRESHOLD = 0.05   # 5%
+
+
+def _classify_incident(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return classification result with severity, components, and SLA."""
+    incident_id = payload.get("incident_id", "?")
+    severity    = payload.get("severity", "P3")
+    service     = payload.get("service", "")
+    symptom     = payload.get("symptom", "")
+    sla_minutes = _SEVERITY_RESPONSE_SLA.get(severity, 60)
+
+    is_critical_service = service in _CRITICAL_SERVICES
+    has_error_rate      = "error rate" in symptom.lower() or "5xx" in symptom.lower()
+
+    affected_components = [service] if service else []
+    if is_critical_service:
+        affected_components.append("downstream-dependents")
+
+    # Suggest escalation path
+    if severity in {"P1", "P2"} and is_critical_service:
+        escalation_path = "on-call → team-lead → engineering-director"
+    elif severity in {"P1", "P2"}:
+        escalation_path = "on-call → team-lead"
+    else:
+        escalation_path = "on-call"
+
+    return {
+        "incident_id":          incident_id,
+        "severity":             severity,
+        "is_critical_service":  is_critical_service,
+        "has_error_rate_signal": has_error_rate,
+        "affected_components":  affected_components,
+        "sla_minutes":          sla_minutes,
+        "escalation_path":      escalation_path,
+        "classification_note":  (
+            f"{incident_id}: {severity} on {service!r} — "
+            f"SLA={sla_minutes}m, escalation: {escalation_path}"
+        ),
+    }
+
+
+def handle_intent(client: AxmeClient, delivery: dict[str, Any]) -> None:
+    intent_id = delivery.get("intent_id", "")
+    if not intent_id:
+        log.warning("received delivery without intent_id, skipping")
+        return
+
+    log.info("received intent %s", intent_id)
+
+    try:
+        resp   = client.get_intent(intent_id)
+        intent = resp.get("intent") or resp
+    except Exception as exc:
+        log.error("get_intent(%s) failed: %s", intent_id, exc)
+        return
+
+    status = (intent.get("lifecycle_status") or intent.get("status") or "").upper()
+    if status not in {"CREATED", "DELIVERED", "ACKNOWLEDGED", "IN_PROGRESS", "WAITING"}:
+        log.debug("skipping intent %s with status %s", intent_id, status)
+        return
+
+    raw_payload       = intent.get("payload") or {}
+    effective_payload = raw_payload.get("parent_payload") or raw_payload
+
+    result = _classify_incident(effective_payload)
+    log.info("classified incident %s: %s", intent_id, result["classification_note"])
+
+    try:
+        client.resume_intent(
+            intent_id,
+            {"action": "complete", **result},
+            owner_agent=AXME_AGENT_ADDRESS,
+        )
+        log.info("resumed intent %s", intent_id)
+    except Exception as exc:
+        log.error("resume_intent(%s) failed: %s", intent_id, exc)
+
+
+def main() -> None:
+    client = AxmeClient(AxmeClientConfig(api_key=AXME_API_KEY, base_url=AXME_BASE_URL))
+    log.info(
+        "incident-classifier starting  address=%s  binding=stream",
+        AXME_AGENT_ADDRESS,
+    )
+
+    try:
+        for delivery in client.listen(AXME_AGENT_ADDRESS, timeout_seconds=None):
+            handle_intent(client, delivery)
+    except KeyboardInterrupt:
+        log.info("shutting down")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/internal/escalation/scenario.json
+++ b/examples/internal/escalation/scenario.json
@@ -1,0 +1,78 @@
+{
+  "scenario_id": "internal.escalation.v1",
+  "title": "Internal escalation — SLA breach triggers reminder chain",
+  "description": "Demonstrates AXME's built-in escalation mechanism. An automated agent validates an incident report, then routes it to the on-call engineer for acknowledgement. If the engineer does not respond within the SLA window, AXME automatically sends reminder emails. After max_reminders are exhausted, the step times out and the intent transitions to TIMED_OUT — triggering an escalation event.",
+
+  "agents": [
+    {
+      "role": "classifier",
+      "address": "incident-classifier-agent",
+      "display_name": "Incident Classifier",
+      "delivery_mode": "stream",
+      "create_if_missing": true
+    }
+  ],
+
+  "humans": [
+    {
+      "role": "oncall",
+      "display_name": "On-Call Engineer"
+    }
+  ],
+
+  "workflow": {
+    "steps": [
+      {
+        "step_id": "classify_incident",
+        "tool_id": "tool.agent.task.v1",
+        "assigned_to": "classifier",
+        "step_deadline_seconds": 60
+      },
+      {
+        "step_id": "oncall_ack",
+        "tool_id": "tool.approval.human_signoff",
+        "assigned_to": "oncall",
+        "requires_approval": true,
+        "step_deadline_seconds": 300,
+        "remind_after_seconds": 60,
+        "remind_interval_seconds": 60,
+        "max_reminders": 3,
+        "human_task": {
+          "title": "Incident acknowledgement required — INC-20260314-001 (P2)",
+          "description": "Acknowledge this P2 incident and provide initial response. SLA: 5 minutes. Reminders every 60 seconds. After 3 reminders without response the incident escalates automatically.",
+          "form_schema": {
+            "type": "object",
+            "required": ["acknowledged"],
+            "properties": {
+              "acknowledged": {
+                "type": "boolean"
+              },
+              "eta_minutes": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Estimated resolution time in minutes"
+              },
+              "notes": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    ]
+  },
+
+  "intent": {
+    "type": "intent.incident.escalation.v1",
+    "payload": {
+      "incident_id":  "INC-20260314-001",
+      "severity":     "P2",
+      "service":      "api-gateway",
+      "environment":  "production",
+      "symptom":      "Elevated 5xx error rate (12%) on /v1/intents endpoint",
+      "started_at":   "2026-03-14T14:00:00Z",
+      "sla_minutes":  5
+    },
+    "max_delivery_attempts": 3
+  }
+}

--- a/examples/internal/notification/agent.py
+++ b/examples/internal/notification/agent.py
@@ -1,0 +1,171 @@
+"""Risk Assessment Agent — internal/notification example.
+
+Delivery: stream  (GET /v1/agents/{address}/intents/stream)
+
+Assesses deployment risk based on number of changes, environment, and
+version jump. If risk exceeds threshold, signals HIGH risk. The workflow
+then triggers the built-in notification step to alert the service owner.
+
+Run (Terminal 1 — agent):
+    export AXME_API_KEY=<your-api-key>
+    export AXME_AGENT_ADDRESS=agent://<org>/<workspace>/risk-assessment-agent
+    python agent.py
+
+Run (Terminal 2 — scenario):
+    axme scenarios apply examples/internal/notification/scenario.json --watch
+
+After the agent step, AXME sends a notification email to the owner and
+waits for acknowledgement. Owner acknowledges via:
+    axme tasks list
+    axme tasks approve <task_id> --result '{"acknowledged":true,"decision":"proceed"}'
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from typing import Any
+
+from axme import AxmeClient, AxmeClientConfig
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s  [%(levelname)s]  %(message)s",
+    datefmt="%H:%M:%S",
+)
+log = logging.getLogger("risk-assessment-agent")
+
+AXME_BASE_URL      = os.environ.get("AXME_BASE_URL", "https://api.cloud.axme.ai")
+AXME_API_KEY       = os.environ.get("AXME_API_KEY", "")
+AXME_AGENT_ADDRESS = os.environ.get("AXME_AGENT_ADDRESS", "risk-assessment-agent")
+
+if not AXME_API_KEY:
+    sys.exit("AXME_API_KEY is required")
+
+
+# ---------------------------------------------------------------------------
+# Risk scoring — real deterministic logic
+# ---------------------------------------------------------------------------
+# Risk score = sum of factor weights.
+# If score >= threshold → HIGH risk, signal for owner notification.
+
+_VERSION_MAJOR_BUMP_WEIGHT = 40    # major version jump (e.g. 3.x → 4.x)
+_VERSION_MINOR_BUMP_WEIGHT = 15    # minor version jump
+_HIGH_CHANGE_COUNT_WEIGHT  = 30    # more than 30 changed files
+_PROD_ENVIRONMENT_WEIGHT   = 25    # production environment
+_STAGING_ENVIRONMENT_WEIGHT = 10   # staging environment
+
+
+def _parse_semver(version: str) -> tuple[int, int, int]:
+    """Parse MAJOR.MINOR.PATCH, return (major, minor, patch) or (0, 0, 0) on error."""
+    try:
+        parts = version.strip().split(".")
+        return int(parts[0]), int(parts[1]), int(parts[2])
+    except Exception:
+        return 0, 0, 0
+
+
+def _assess_risk(payload: dict[str, Any]) -> tuple[int, str, list[str]]:
+    """Return (risk_score, risk_level, factors)."""
+    version      = payload.get("version", "0.0.0")
+    environment  = payload.get("environment", "")
+    change_count = int(payload.get("change_count", 0))
+    threshold    = int(payload.get("risk_threshold", 30))
+
+    major, minor, _ = _parse_semver(version)
+
+    score:   int        = 0
+    factors: list[str]  = []
+
+    # Version jump factors
+    if major >= 4:
+        score += _VERSION_MAJOR_BUMP_WEIGHT
+        factors.append(f"major version bump (v{major}.x) +{_VERSION_MAJOR_BUMP_WEIGHT}")
+    elif minor >= 5:
+        score += _VERSION_MINOR_BUMP_WEIGHT
+        factors.append(f"significant minor version bump +{_VERSION_MINOR_BUMP_WEIGHT}")
+
+    # Change volume factor
+    if change_count > 30:
+        score += _HIGH_CHANGE_COUNT_WEIGHT
+        factors.append(f"high change count ({change_count} changes) +{_HIGH_CHANGE_COUNT_WEIGHT}")
+
+    # Environment factor
+    if environment == "production":
+        score += _PROD_ENVIRONMENT_WEIGHT
+        factors.append(f"production environment +{_PROD_ENVIRONMENT_WEIGHT}")
+    elif environment in {"staging", "canary"}:
+        score += _STAGING_ENVIRONMENT_WEIGHT
+        factors.append(f"staging environment +{_STAGING_ENVIRONMENT_WEIGHT}")
+
+    if score >= threshold:
+        risk_level = "HIGH"
+    elif score >= threshold // 2:
+        risk_level = "MEDIUM"
+    else:
+        risk_level = "LOW"
+
+    return score, risk_level, factors
+
+
+def handle_intent(client: AxmeClient, delivery: dict[str, Any]) -> None:
+    intent_id = delivery.get("intent_id", "")
+    if not intent_id:
+        log.warning("received delivery without intent_id, skipping")
+        return
+
+    log.info("received intent %s", intent_id)
+
+    try:
+        resp   = client.get_intent(intent_id)
+        intent = resp.get("intent") or resp
+    except Exception as exc:
+        log.error("get_intent(%s) failed: %s", intent_id, exc)
+        return
+
+    status = (intent.get("lifecycle_status") or intent.get("status") or "").upper()
+    if status not in {"CREATED", "DELIVERED", "ACKNOWLEDGED", "IN_PROGRESS", "WAITING"}:
+        log.debug("skipping intent %s with status %s", intent_id, status)
+        return
+
+    raw_payload       = intent.get("payload") or {}
+    effective_payload = raw_payload.get("parent_payload") or raw_payload
+
+    score, risk_level, factors = _assess_risk(effective_payload)
+    log.info(
+        "risk assessment for %s: score=%d  level=%s  factors=%d",
+        intent_id, score, risk_level, len(factors),
+    )
+
+    try:
+        client.resume_intent(
+            intent_id,
+            {
+                "action":     "complete",
+                "risk_score": score,
+                "risk_level": risk_level,
+                "factors":    factors,
+            },
+            owner_agent=AXME_AGENT_ADDRESS,
+        )
+        log.info("resumed intent %s (risk=%s score=%d)", intent_id, risk_level, score)
+    except Exception as exc:
+        log.error("resume_intent(%s) failed: %s", intent_id, exc)
+
+
+def main() -> None:
+    client = AxmeClient(AxmeClientConfig(api_key=AXME_API_KEY, base_url=AXME_BASE_URL))
+    log.info(
+        "risk-assessment-agent starting  address=%s  binding=stream",
+        AXME_AGENT_ADDRESS,
+    )
+
+    try:
+        for delivery in client.listen(AXME_AGENT_ADDRESS, timeout_seconds=None):
+            handle_intent(client, delivery)
+    except KeyboardInterrupt:
+        log.info("shutting down")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/internal/notification/scenario.json
+++ b/examples/internal/notification/scenario.json
@@ -1,0 +1,78 @@
+{
+  "scenario_id": "internal.notification.v1",
+  "title": "Internal notification — risk alert with owner notification",
+  "description": "An automated agent assesses deployment risk. If the risk level is elevated, AXME automatically notifies the owner via the built-in `tool.notification.notify_owner` step — sending an email with the alert details and waiting for acknowledgement.",
+
+  "agents": [
+    {
+      "role": "assessor",
+      "address": "risk-assessment-agent",
+      "display_name": "Risk Assessment Agent",
+      "delivery_mode": "stream",
+      "create_if_missing": true
+    }
+  ],
+
+  "humans": [
+    {
+      "role": "owner",
+      "display_name": "Service Owner"
+    }
+  ],
+
+  "workflow": {
+    "steps": [
+      {
+        "step_id": "assess_risk",
+        "tool_id": "tool.agent.task.v1",
+        "assigned_to": "assessor",
+        "step_deadline_seconds": 60
+      },
+      {
+        "step_id": "notify_owner",
+        "tool_id": "tool.notification.notify_owner",
+        "assigned_to": "owner",
+        "requires_approval": true,
+        "step_deadline_seconds": 3600,
+        "remind_after_seconds": 600,
+        "remind_interval_seconds": 600,
+        "max_reminders": 2,
+        "human_task": {
+          "title": "Risk alert — api-gateway deployment risk: HIGH",
+          "description": "Risk assessment has flagged this deployment as HIGH risk. Review the risk report and acknowledge to proceed or reject to halt.",
+          "form_schema": {
+            "type": "object",
+            "required": ["acknowledged"],
+            "properties": {
+              "acknowledged": {
+                "type": "boolean",
+                "description": "Confirm you have reviewed the risk assessment"
+              },
+              "decision": {
+                "type": "string",
+                "enum": ["proceed", "halt", "defer"],
+                "description": "Decision on the deployment"
+              },
+              "notes": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    ]
+  },
+
+  "intent": {
+    "type": "intent.deployment.risk_alert.v1",
+    "payload": {
+      "deploy_id":     "deploy-20260314-002",
+      "service":       "api-gateway",
+      "version":       "4.0.0",
+      "environment":   "staging",
+      "change_count":  47,
+      "risk_threshold": 30
+    },
+    "max_delivery_attempts": 3
+  }
+}


### PR DESCRIPTION
## Summary

**Internal runtime examples:**
- `internal/delay` — `change-window-validator` (stream) + demonstrates `step_deadline_seconds` mechanism
- `internal/notification` — `risk-assessment-agent` (stream) + `tool.notification.notify_owner` step (sends email + waits for acknowledgement)
- `internal/escalation` — `incident-classifier` (stream) + human ack step with `remind_after_seconds: 60`, `max_reminders: 3` — demonstrates automatic reminder chain and escalation

**Fix:** Replace `tool.human.approval.v1` → `tool.approval.human_signoff` in all `human/*` scenario.json files. The former doesn't exist in the tool registry and would cause "unknown tool_id" compilation errors.

## Test plan

- [ ] `axme scenarios apply examples/internal/escalation/scenario.json --watch` — see `[reminder]` events when on-call does not respond
- [ ] `axme scenarios apply examples/internal/delay/scenario.json --watch` — see TIMED_OUT if agent not running
- [ ] `axme scenarios apply examples/human/cli/scenario.json --watch` — verify human step now compiles correctly with fixed tool_id

🤖 Generated with [Claude Code](https://claude.com/claude-code)