### PR TITLE
feat(durability): retry-failure, timeout, reminder-escalation examples

### DIFF
--- a/examples/durability/reminder-escalation/agent.py
+++ b/examples/durability/reminder-escalation/agent.py
@@ -1,0 +1,132 @@
+"""Pre-Approval Validator — durability/reminder-escalation example.
+
+Delivery: stream  (GET /v1/agents/{address}/intents/stream)
+
+Validates a change request before routing to the human approver.
+The human approval step has a short SLA with reminders configured.
+
+Run (Terminal 1 — agent):
+    export AXME_API_KEY=<your-api-key>
+    export AXME_AGENT_ADDRESS=agent://<org>/<workspace>/pre-approval-validator
+    python agent.py
+
+Run (Terminal 2 — scenario):
+    axme scenarios apply examples/durability/reminder-escalation/scenario.json --watch
+
+To observe escalation: run the scenario but do NOT approve the task.
+Watch [reminder] events every 30 seconds, then TIMED_OUT after max_reminders.
+To approve normally: axme tasks list → axme tasks approve <task_id>
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from typing import Any
+
+from axme import AxmeClient, AxmeClientConfig
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s  [%(levelname)s]  %(message)s",
+    datefmt="%H:%M:%S",
+)
+log = logging.getLogger("pre-approval-validator")
+
+AXME_BASE_URL      = os.environ.get("AXME_BASE_URL", "https://api.cloud.axme.ai")
+AXME_API_KEY       = os.environ.get("AXME_API_KEY", "")
+AXME_AGENT_ADDRESS = os.environ.get("AXME_AGENT_ADDRESS", "pre-approval-validator")
+
+if not AXME_API_KEY:
+    sys.exit("AXME_API_KEY is required")
+
+_ALLOWED_CHANGE_TYPES = {"config_update", "dependency_update", "rollback", "hotfix"}
+_VALID_RISK_LEVELS    = {"low", "medium", "high", "critical"}
+
+
+def _validate_change(payload: dict[str, Any]) -> tuple[bool, str]:
+    """Return (valid, reason) — pre-flight validation before human approval."""
+    change_id   = payload.get("change_id", "?")
+    change_type = payload.get("change_type", "")
+    risk_level  = payload.get("risk_level", "")
+    service     = payload.get("service", "")
+    environment = payload.get("environment", "")
+
+    if not service:
+        return False, f"{change_id}: service is required"
+
+    if change_type not in _ALLOWED_CHANGE_TYPES:
+        return (
+            False,
+            f"{change_id}: change_type {change_type!r} not in {sorted(_ALLOWED_CHANGE_TYPES)}",
+        )
+
+    if risk_level not in _VALID_RISK_LEVELS:
+        return (
+            False,
+            f"{change_id}: risk_level {risk_level!r} not in {sorted(_VALID_RISK_LEVELS)}",
+        )
+
+    return (
+        True,
+        f"{change_id}: pre-validation passed for {service!r}/{environment!r} ({change_type}, {risk_level} risk)",
+    )
+
+
+def handle_intent(client: AxmeClient, delivery: dict[str, Any]) -> None:
+    intent_id = delivery.get("intent_id", "")
+    if not intent_id:
+        log.warning("received delivery without intent_id, skipping")
+        return
+
+    log.info("received intent %s", intent_id)
+
+    try:
+        resp   = client.get_intent(intent_id)
+        intent = resp.get("intent") or resp
+    except Exception as exc:
+        log.error("get_intent(%s) failed: %s", intent_id, exc)
+        return
+
+    status = (intent.get("lifecycle_status") or intent.get("status") or "").upper()
+    if status not in {"CREATED", "DELIVERED", "ACKNOWLEDGED", "IN_PROGRESS", "WAITING"}:
+        log.debug("skipping intent %s with status %s", intent_id, status)
+        return
+
+    raw_payload       = intent.get("payload") or {}
+    effective_payload = raw_payload.get("parent_payload") or raw_payload
+
+    valid, reason = _validate_change(effective_payload)
+    log.info("pre-validation for %s: valid=%s  reason=%s", intent_id, valid, reason)
+
+    try:
+        if valid:
+            client.resume_intent(
+                intent_id,
+                {"action": "complete", "valid": True, "reason": reason},
+                owner_agent=AXME_AGENT_ADDRESS,
+            )
+        else:
+            client.resume_intent(
+                intent_id,
+                {"action": "fail", "valid": False, "reason": reason},
+                owner_agent=AXME_AGENT_ADDRESS,
+            )
+        log.info("resumed intent %s (valid=%s)", intent_id, valid)
+    except Exception as exc:
+        log.error("resume_intent(%s) failed: %s", intent_id, exc)
+
+
+def main() -> None:
+    client = AxmeClient(AxmeClientConfig(api_key=AXME_API_KEY, base_url=AXME_BASE_URL))
+    log.info("pre-approval-validator starting  address=%s  binding=stream", AXME_AGENT_ADDRESS)
+
+    try:
+        for delivery in client.listen(AXME_AGENT_ADDRESS, timeout_seconds=None):
+            handle_intent(client, delivery)
+    except KeyboardInterrupt:
+        log.info("shutting down")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/durability/reminder-escalation/scenario.json
+++ b/examples/durability/reminder-escalation/scenario.json
@@ -1,0 +1,68 @@
+{
+  "scenario_id": "durability.reminder_escalation.v1",
+  "title": "Durability — human SLA breach, reminders, and escalation",
+  "description": "Demonstrates AXME's reminder and escalation durability primitives. A validator agent processes the change request, then routes for human sign-off with a tight SLA. If the approver does not respond: (1) AXME sends reminder emails at configured intervals, (2) after max_reminders are exhausted, the step transitions to TIMED_OUT, and (3) the parent intent transitions to FAILED — providing a full audit trail.",
+
+  "agents": [
+    {
+      "role": "validator",
+      "address": "pre-approval-validator",
+      "display_name": "Pre-Approval Validator",
+      "delivery_mode": "stream",
+      "create_if_missing": true
+    }
+  ],
+
+  "humans": [
+    {
+      "role": "approver",
+      "display_name": "Change Approver"
+    }
+  ],
+
+  "workflow": {
+    "steps": [
+      {
+        "step_id": "pre_validate",
+        "tool_id": "tool.agent.task.v1",
+        "assigned_to": "validator",
+        "step_deadline_seconds": 60
+      },
+      {
+        "step_id": "change_approval",
+        "tool_id": "tool.approval.human_signoff",
+        "assigned_to": "approver",
+        "requires_approval": true,
+        "step_deadline_seconds": 180,
+        "remind_after_seconds": 30,
+        "remind_interval_seconds": 30,
+        "max_reminders": 3,
+        "human_task": {
+          "title": "Change approval required — CHG-20260314-004",
+          "description": "Approve or reject this infrastructure change. SLA: 3 minutes. Reminders every 30 seconds. After 3 reminders the change is auto-rejected.",
+          "form_schema": {
+            "type": "object",
+            "required": ["approved"],
+            "properties": {
+              "approved": { "type": "boolean" },
+              "notes":    { "type": "string" }
+            }
+          }
+        }
+      }
+    ]
+  },
+
+  "intent": {
+    "type": "intent.change.approval.v1",
+    "payload": {
+      "change_id":    "CHG-20260314-004",
+      "service":      "auth-service",
+      "environment":  "staging",
+      "change_type":  "config_update",
+      "risk_level":   "low",
+      "description":  "Update rate limiting config: increase burst to 200 req/s"
+    },
+    "max_delivery_attempts": 3
+  }
+}

--- a/examples/durability/retry-failure/agent.py
+++ b/examples/durability/retry-failure/agent.py
@@ -1,0 +1,115 @@
+"""Webhook Receiver Agent — durability/retry-failure example.
+
+Delivery: stream  (GET /v1/agents/{address}/intents/stream)
+
+Processes incoming webhook events. In this durability test scenario:
+- Run WITH the agent: intent is processed normally → COMPLETED
+- Run WITHOUT the agent: AXME retries delivery up to max_delivery_attempts,
+  then transitions to FAILED with `intent.delivery_failed` event
+
+Run (normal completion):
+    export AXME_API_KEY=<your-api-key>
+    export AXME_AGENT_ADDRESS=agent://<org>/<workspace>/webhook-receiver-agent
+    python agent.py
+    axme scenarios apply examples/durability/retry-failure/scenario.json --watch
+
+Run (to observe retry behavior):
+    # Do NOT start agent.py
+    axme scenarios apply examples/durability/retry-failure/scenario.json --watch
+    # Watch AXME retry delivery and eventually emit intent.delivery_failed
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import sys
+from typing import Any
+
+from axme import AxmeClient, AxmeClientConfig
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s  [%(levelname)s]  %(message)s",
+    datefmt="%H:%M:%S",
+)
+log = logging.getLogger("webhook-receiver")
+
+AXME_BASE_URL      = os.environ.get("AXME_BASE_URL", "https://api.cloud.axme.ai")
+AXME_API_KEY       = os.environ.get("AXME_API_KEY", "")
+AXME_AGENT_ADDRESS = os.environ.get("AXME_AGENT_ADDRESS", "webhook-receiver-agent")
+
+if not AXME_API_KEY:
+    sys.exit("AXME_API_KEY is required")
+
+
+def _process_webhook(payload: dict[str, Any]) -> dict[str, Any]:
+    """Process incoming webhook event — real idempotent processing."""
+    event_type = payload.get("event_type", "unknown")
+    source     = payload.get("source", "")
+    test_id    = payload.get("test_id", "")
+
+    # Generate a deterministic fingerprint for idempotency tracking
+    fingerprint = hashlib.sha256(
+        f"{event_type}:{source}:{test_id}".encode()
+    ).hexdigest()[:16]
+
+    return {
+        "event_type":   event_type,
+        "source":       source,
+        "fingerprint":  fingerprint,
+        "processed":    True,
+        "note":         f"webhook event {event_type!r} processed from {source!r}",
+    }
+
+
+def handle_intent(client: AxmeClient, delivery: dict[str, Any]) -> None:
+    intent_id = delivery.get("intent_id", "")
+    if not intent_id:
+        log.warning("received delivery without intent_id, skipping")
+        return
+
+    log.info("received intent %s", intent_id)
+
+    try:
+        resp   = client.get_intent(intent_id)
+        intent = resp.get("intent") or resp
+    except Exception as exc:
+        log.error("get_intent(%s) failed: %s", intent_id, exc)
+        return
+
+    status = (intent.get("lifecycle_status") or intent.get("status") or "").upper()
+    if status not in {"CREATED", "DELIVERED", "ACKNOWLEDGED", "IN_PROGRESS", "WAITING"}:
+        log.debug("skipping intent %s with status %s", intent_id, status)
+        return
+
+    raw_payload       = intent.get("payload") or {}
+    effective_payload = raw_payload.get("parent_payload") or raw_payload
+
+    result = _process_webhook(effective_payload)
+    log.info("processed webhook for %s: fingerprint=%s", intent_id, result["fingerprint"])
+
+    try:
+        client.resume_intent(
+            intent_id,
+            {"action": "complete", **result},
+            owner_agent=AXME_AGENT_ADDRESS,
+        )
+        log.info("resumed intent %s", intent_id)
+    except Exception as exc:
+        log.error("resume_intent(%s) failed: %s", intent_id, exc)
+
+
+def main() -> None:
+    client = AxmeClient(AxmeClientConfig(api_key=AXME_API_KEY, base_url=AXME_BASE_URL))
+    log.info("webhook-receiver starting  address=%s  binding=stream", AXME_AGENT_ADDRESS)
+
+    try:
+        for delivery in client.listen(AXME_AGENT_ADDRESS, timeout_seconds=None):
+            handle_intent(client, delivery)
+    except KeyboardInterrupt:
+        log.info("shutting down")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/durability/retry-failure/scenario.json
+++ b/examples/durability/retry-failure/scenario.json
@@ -1,0 +1,37 @@
+{
+  "scenario_id": "durability.retry_failure.v1",
+  "title": "Durability — delivery retry and FAILED transition",
+  "description": "Demonstrates AXME's built-in retry mechanism. The webhook-receiver agent is intentionally unavailable. AXME retries delivery up to max_delivery_attempts times with backoff. After all attempts are exhausted, the intent transitions to FAILED and emits an `intent.delivery_failed` lifecycle event.",
+
+  "agents": [
+    {
+      "role": "receiver",
+      "address": "webhook-receiver-agent",
+      "display_name": "Webhook Receiver",
+      "delivery_mode": "stream",
+      "create_if_missing": true
+    }
+  ],
+
+  "workflow": {
+    "steps": [
+      {
+        "step_id": "process_webhook",
+        "tool_id": "tool.agent.task.v1",
+        "assigned_to": "receiver",
+        "step_deadline_seconds": 30
+      }
+    ]
+  },
+
+  "intent": {
+    "type": "intent.webhook.delivery_test.v1",
+    "payload": {
+      "event_type":   "webhook.test.retry",
+      "source":       "durability-test",
+      "test_id":      "retry-failure-20260314",
+      "description":  "This intent is used to test retry-on-failure behavior. Run WITHOUT starting the agent to observe retries and final FAILED status."
+    },
+    "max_delivery_attempts": 3
+  }
+}

--- a/examples/durability/timeout/agent.py
+++ b/examples/durability/timeout/agent.py
@@ -1,0 +1,128 @@
+"""Slow Batch Processor — durability/timeout example.
+
+Delivery: stream  (GET /v1/agents/{address}/intents/stream)
+
+Demonstrates AXME's step deadline enforcement. This agent processes
+batch intents normally. The scenario is configured with a very short
+`step_deadline_seconds: 10`. The agent validates the batch parameters
+but rejects oversized batches (above _MAX_BATCH_RECORDS) to simulate
+a legitimate processing constraint.
+
+The timeout demonstration:
+- The scenario.json sets step_deadline_seconds=10
+- Run WITHOUT the agent: AXME delivers the intent but no one picks it up
+- After 10 seconds: AXME transitions the step to TIMED_OUT
+
+Run (to observe timeout):
+    # Do NOT start agent.py
+    axme scenarios apply examples/durability/timeout/scenario.json --watch
+    # Watch step_deadline_seconds elapse → TIMED_OUT
+
+Run (normal completion — agent rejects oversized batch):
+    export AXME_API_KEY=<your-api-key>
+    export AXME_AGENT_ADDRESS=agent://<org>/<workspace>/slow-batch-processor
+    python agent.py
+    axme scenarios apply examples/durability/timeout/scenario.json --watch
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from typing import Any
+
+from axme import AxmeClient, AxmeClientConfig
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s  [%(levelname)s]  %(message)s",
+    datefmt="%H:%M:%S",
+)
+log = logging.getLogger("slow-batch-processor")
+
+AXME_BASE_URL      = os.environ.get("AXME_BASE_URL", "https://api.cloud.axme.ai")
+AXME_API_KEY       = os.environ.get("AXME_API_KEY", "")
+AXME_AGENT_ADDRESS = os.environ.get("AXME_AGENT_ADDRESS", "slow-batch-processor")
+
+if not AXME_API_KEY:
+    sys.exit("AXME_API_KEY is required")
+
+_MAX_BATCH_RECORDS = 10_000   # reject batches larger than this
+
+
+def _process_batch(payload: dict[str, Any]) -> tuple[bool, dict[str, Any]]:
+    """Return (ok, result). Rejects oversized batches."""
+    batch_id     = payload.get("batch_id", "?")
+    record_count = int(payload.get("record_count", 0))
+
+    if record_count > _MAX_BATCH_RECORDS:
+        return False, {
+            "batch_id":    batch_id,
+            "error":       f"batch too large: {record_count} records exceeds limit of {_MAX_BATCH_RECORDS}",
+            "record_count": record_count,
+        }
+
+    return True, {
+        "batch_id":      batch_id,
+        "record_count":  record_count,
+        "processed":     True,
+    }
+
+
+def handle_intent(client: AxmeClient, delivery: dict[str, Any]) -> None:
+    intent_id = delivery.get("intent_id", "")
+    if not intent_id:
+        log.warning("received delivery without intent_id, skipping")
+        return
+
+    log.info("received intent %s", intent_id)
+
+    try:
+        resp   = client.get_intent(intent_id)
+        intent = resp.get("intent") or resp
+    except Exception as exc:
+        log.error("get_intent(%s) failed: %s", intent_id, exc)
+        return
+
+    status = (intent.get("lifecycle_status") or intent.get("status") or "").upper()
+    if status not in {"CREATED", "DELIVERED", "ACKNOWLEDGED", "IN_PROGRESS", "WAITING"}:
+        log.debug("skipping intent %s with status %s", intent_id, status)
+        return
+
+    raw_payload       = intent.get("payload") or {}
+    effective_payload = raw_payload.get("parent_payload") or raw_payload
+
+    ok, result = _process_batch(effective_payload)
+    log.info("batch result for %s: ok=%s", intent_id, ok)
+
+    try:
+        if ok:
+            client.resume_intent(
+                intent_id,
+                {"action": "complete", **result},
+                owner_agent=AXME_AGENT_ADDRESS,
+            )
+        else:
+            client.resume_intent(
+                intent_id,
+                {"action": "fail", **result},
+                owner_agent=AXME_AGENT_ADDRESS,
+            )
+        log.info("resumed intent %s", intent_id)
+    except Exception as exc:
+        log.error("resume_intent(%s) failed: %s", intent_id, exc)
+
+
+def main() -> None:
+    client = AxmeClient(AxmeClientConfig(api_key=AXME_API_KEY, base_url=AXME_BASE_URL))
+    log.info("slow-batch-processor starting  address=%s  binding=stream", AXME_AGENT_ADDRESS)
+
+    try:
+        for delivery in client.listen(AXME_AGENT_ADDRESS, timeout_seconds=None):
+            handle_intent(client, delivery)
+    except KeyboardInterrupt:
+        log.info("shutting down")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/durability/timeout/scenario.json
+++ b/examples/durability/timeout/scenario.json
@@ -1,0 +1,36 @@
+{
+  "scenario_id": "durability.timeout.v1",
+  "title": "Durability — step deadline and TIMED_OUT transition",
+  "description": "Demonstrates AXME's step-level deadline enforcement. The batch-processor agent receives an intent but intentionally takes longer than `step_deadline_seconds` to respond. AXME transitions the intent to TIMED_OUT and emits an `intent.timed_out` lifecycle event.",
+
+  "agents": [
+    {
+      "role": "processor",
+      "address": "slow-batch-processor",
+      "display_name": "Slow Batch Processor",
+      "delivery_mode": "stream",
+      "create_if_missing": true
+    }
+  ],
+
+  "workflow": {
+    "steps": [
+      {
+        "step_id": "process_batch",
+        "tool_id": "tool.agent.task.v1",
+        "assigned_to": "processor",
+        "step_deadline_seconds": 10
+      }
+    ]
+  },
+
+  "intent": {
+    "type": "intent.batch.timeout_test.v1",
+    "payload": {
+      "batch_id":    "batch-timeout-20260314",
+      "record_count": 1000000,
+      "description": "Large batch that takes longer than step_deadline_seconds=10 to process. Agent will NOT respond in time, demonstrating AXME TIMED_OUT transition."
+    },
+    "max_delivery_attempts": 1
+  }
+}


### PR DESCRIPTION
## Summary

Three durability examples showing AXME's built-in fault tolerance:

- **`durability/retry-failure`** — run WITHOUT the agent to observe `max_delivery_attempts=3` exhausted → `intent.delivery_failed`
- **`durability/timeout`** — run WITHOUT the agent to observe `step_deadline_seconds=10` elapsed → `TIMED_OUT`
- **`durability/reminder-escalation`** — don't approve the human task to see `remind_after_seconds=30`, `max_reminders=3` → reminder email chain → `TIMED_OUT`

## Test plan

- [ ] `axme scenarios apply examples/durability/retry-failure/scenario.json --watch` (no agent running) — see retries then FAILED
- [ ] `axme scenarios apply examples/durability/timeout/scenario.json --watch` (no agent running) — see TIMED_OUT after 10s
- [ ] `axme scenarios apply examples/durability/reminder-escalation/scenario.json --watch` — agent completes step 1, then wait for reminders on step 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)