### PR TITLE
fix: update go.mod to published axme-sdk-go v0.1.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/AxmeAI/axme-examples
+
+go 1.22
+
+require github.com/AxmeAI/axme-sdk-go v0.1.2

--- a/lang/go/go.mod
+++ b/lang/go/go.mod
@@ -1,7 +1,0 @@
-module github.com/AxmeAI/axme-examples
-
-go 1.22
-
-require github.com/AxmeAI/axme-sdk-go v0.1.1
-
-replace github.com/AxmeAI/axme-sdk-go => ../axme-sdk-go


### PR DESCRIPTION
## Summary
- Remove `replace` directive, use published `v0.1.2` tag
- Move `go.mod` from `lang/go/` to repo root (Go needs module root to find `examples/**/*.go` files)

## Test plan
- [x] `go mod tidy` resolves v0.1.2
- [x] `go vet ./examples/delivery/stream/go/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)