### PR TITLE
Clarify delivery README covers 4 external modes

### DIFF
--- a/examples/delivery/README.md
+++ b/examples/delivery/README.md
@@ -1,6 +1,8 @@
 # Delivery Bindings — Examples
 
-All four AXME delivery modes, each as a self-contained `agent.py` + `scenario.json`.
+The four external AXME delivery modes, each as a self-contained `agent.py` + `scenario.json`.
+
+> **Note:** The fifth binding, `internal`, runs inside agent-core and is covered in `examples/internal/`.
 
 ## Quickstart
 


### PR DESCRIPTION
## Summary
- Clarify that `delivery/` covers the 4 external delivery modes (stream, poll, http, inbox)
- Add note pointing to `examples/internal/` for the fifth binding (internal)

## Test plan
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)