### PR TITLE
docs: add source hint after CLI install

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,5 +206,5 @@ All examples use AXME SDK v0.1.2:
 
 ## Alpha Access
 
-Install the CLI and log in: `curl -fsSL https://raw.githubusercontent.com/AxmeAI/axme-cli/main/install.sh | sh && axme login`
+Install the CLI and log in: `curl -fsSL https://raw.githubusercontent.com/AxmeAI/axme-cli/main/install.sh | sh && source ~/.zshrc && axme login`
 Contact: hello@axme.ai


### PR DESCRIPTION
## Summary
- Add `source ~/.zshrc` to the one-liner install command in Alpha Access section

## Test plan
- [ ] Verify README renders correctly