### PR TITLE
docs: replace source ~/.zshrc with generic installer hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,5 +206,5 @@ All examples use AXME SDK v0.1.2:
 
 ## Alpha Access
 
-Install the CLI and log in: `curl -fsSL https://raw.githubusercontent.com/AxmeAI/axme-cli/main/install.sh | sh && source ~/.zshrc && axme login`
+Install the CLI and log in: `curl -fsSL https://raw.githubusercontent.com/AxmeAI/axme-cli/main/install.sh | sh` (open a new terminal, then `axme login`)
 Contact: hello@axme.ai


### PR DESCRIPTION
## Summary
- Replace inline `source ~/.zshrc` in the Alpha Access one-liner with a shell-agnostic instruction
- The install script already prints the correct source command for the user's shell (bash/zsh/fish), so docs should not hardcode zsh

## Files changed
- `README.md` — Alpha Access section