### PR TITLE
fix: update SDK deps to 0.1.2 and clean up .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,5 @@ dist/
 package-lock.json
 go.sum
 **/target/
-**/bin/Debug/
-**/bin/Release/
+**/bin/
 **/obj/

--- a/lang/dotnet/AxmeExamples.csproj
+++ b/lang/dotnet/AxmeExamples.csproj
@@ -7,6 +7,6 @@
     <StartupObject>$(ExampleClass)</StartupObject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Axme" Version="0.1.1" />
+    <PackageReference Include="Axme" Version="0.1.2" />
   </ItemGroup>
 </Project>

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>ai.axme</groupId>
             <artifactId>axme</artifactId>
-            <version>0.1.1</version>
+            <version>0.1.2</version>
         </dependency>
     </dependencies>
     <build>

--- a/lang/typescript/package.json
+++ b/lang/typescript/package.json
@@ -8,7 +8,7 @@
     "ts": "tsx"
   },
   "dependencies": {
-    "@axme/axme": "file:../axme-sdk-typescript"
+    "@axme/axme": "^0.1.2"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",


### PR DESCRIPTION
## Summary

- **TypeScript**: Replace local `file:../axme-sdk-typescript` reference with published npm package `@axme/axme` at `^0.1.2`
- **Java**: Bump `ai.axme:axme` dependency from 0.1.1 to 0.1.2 in `pom.xml`
- **.NET**: Bump `Axme` package reference from 0.1.1 to 0.1.2 in `AxmeExamples.csproj`
- **.gitignore**: Consolidate `**/bin/Debug/` and `**/bin/Release/` into `**/bin/` for broader coverage of .NET build artifacts

## Test plan

- [ ] Verify TypeScript examples resolve `@axme/axme` from npm registry
- [ ] Verify Java examples compile against axme 0.1.2 from Maven Central
- [ ] Verify .NET examples restore Axme 0.1.2 from NuGet
- [ ] Confirm .gitignore correctly ignores `bin/`, `obj/`, and `target/` directories